### PR TITLE
7 database builder write the document sink interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,7 +186,7 @@ cython_debug/
 #  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
 #  and can be added to the global gitignore or merged into this file. However, if you prefer, 
 #  you could uncomment the following to ignore the entire vscode folder
-# .vscode/
+.vscode/
 
 # Ruff stuff:
 .ruff_cache/

--- a/pixi.lock
+++ b/pixi.lock
@@ -1776,7 +1776,7 @@ packages:
 - pypi: ./
   name: database-builder
   version: 0.1.0
-  sha256: f4083b6539b828f8ddc0f0f5e09af2f39abf879e1de98675984d13d5b7a0e8f0
+  sha256: 2a7e59b82f0b91a8b4c4d0f9a770b790da381b67ecd4fdeb2587bd7112070dee
   requires_python: '>=3.11'
   editable: true
 - conda: https://conda.anaconda.org/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda

--- a/pixi.lock
+++ b/pixi.lock
@@ -1776,7 +1776,7 @@ packages:
 - pypi: ./
   name: database-builder
   version: 0.1.0
-  sha256: 2a7e59b82f0b91a8b4c4d0f9a770b790da381b67ecd4fdeb2587bd7112070dee
+  sha256: f4083b6539b828f8ddc0f0f5e09af2f39abf879e1de98675984d13d5b7a0e8f0
   requires_python: '>=3.11'
   editable: true
 - conda: https://conda.anaconda.org/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ exclude = [
 ]
 
 [tool.ruff.lint]
-select = ["E4", "E7", "E9", "F", "C4", "PT"]
+select = ["B024", "E4", "E7", "E9", "F", "C4", "PT"]
 
 [tool.ruff]
 exclude = [".pixi", "tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ exclude = [
 ]
 
 [tool.ruff.lint]
-select = ["B024", "E4", "E7", "E9", "F", "C4", "PT"]
+select = ["E4", "E7", "E9", "F", "C4", "PT"]
 
 [tool.ruff]
 exclude = [".pixi", "tests"]

--- a/src/backend/sinks/abstract_sink.py
+++ b/src/backend/sinks/abstract_sink.py
@@ -1,33 +1,60 @@
 from abc import ABC, abstractmethod
 
-from dataclasses import dataclass
 from functools import singledispatchmethod
 
 from backend.stores.qdrant_store import QdrantDatastore
 from backend.stores.typedb_store import TypeDbDatastore
 from backend.stores.store import Datastore
 
-@dataclass
 class AbstractSink(ABC):
+    """
+    Abstract base class that should be implemented by datasources to save entities and relations to various datastores.
+    """
     type: str
-    hash_value: str
 
-    @abstractmethod
     @singledispatchmethod
-    def save_entity(self, store: "Datastore") -> None: ...
+    def save_entity(self, entity: dict, store: Datastore) -> None:
+        """
+        Save an entity to the specified datastore.
+        This is an overloaded method that routes to type-specific implementations based on the datastore type.
+        Args:
+            entity (dict): The entity data to save. The dict should be structured according to the source.
+            store (Datastore): The datastore instance where the entity will be saved.
+        Raises:
+            NotImplementedError: If no implementation exists for the given store type.
+        """
+        raise NotImplementedError(f"No implementation for {type(store)}")
 
-    @abstractmethod
     @save_entity.register
-    def _(self, store: "QdrantDatastore") -> None: ...
+    def _(self, entity: dict, store: QdrantDatastore) -> None:
+        self._save_qdrant_entity(entity, store)
 
     @abstractmethod
+    def _save_qdrant_entity(self, entity: dict, store: QdrantDatastore) -> None: ...
+
     @save_entity.register
-    def _(self, store: "TypeDbDatastore") -> None: ...
+    def _(self, entity: dict, store: TypeDbDatastore) -> None:
+        self._save_typedb_entity(entity, store)
 
     @abstractmethod
+    def _save_typedb_entity(self, entity: dict, store: TypeDbDatastore) -> None: ...
+
     @singledispatchmethod
-    def save_relation(self, store: "Datastore") -> None: ...
+    def save_relation(self, relation: dict, store: Datastore) -> None:
+        """
+        Save a relation to the specified datastore.
+        This is an overloaded method that routes to type-specific implementations based on the datastore type.
+        Args:
+            relation (dict): The relation data to save. The dict should be structured according to the source.
+            store (Datastore): The datastore instance where the relation will be saved.
+        Raises:
+            NotImplementedError: If no implementation exists for the given store type.
+        """
+        raise NotImplementedError(f"No implementation for {type(store)}")
 
-    @abstractmethod
     @save_relation.register
-    def _(self, store: "TypeDbDatastore") -> None: ...
+    def _(self, relation: dict, store: TypeDbDatastore) -> None:
+        self._save_typedb_relation(relation, store)
+
+    @abstractmethod
+    def _save_typedb_relation(self, relation: dict, store: TypeDbDatastore) -> None: ...

--- a/src/backend/sinks/abstract_sink.py
+++ b/src/backend/sinks/abstract_sink.py
@@ -1,0 +1,33 @@
+from abc import ABC, abstractmethod
+
+from dataclasses import dataclass
+from functools import singledispatchmethod
+
+from backend.stores.qdrant_store import QdrantDatastore
+from backend.stores.typedb_store import TypeDbDatastore
+from backend.stores.store import Datastore
+
+@dataclass
+class AbstractSink(ABC):
+    type: str
+    hash_value: str
+
+    @abstractmethod
+    @singledispatchmethod
+    def save_entity(self, store: "Datastore") -> None: ...
+
+    @abstractmethod
+    @save_entity.register
+    def _(self, store: "QdrantDatastore") -> None: ...
+
+    @abstractmethod
+    @save_entity.register
+    def _(self, store: "TypeDbDatastore") -> None: ...
+
+    @abstractmethod
+    @singledispatchmethod
+    def save_relation(self, store: "Datastore") -> None: ...
+
+    @abstractmethod
+    @save_relation.register
+    def _(self, store: "TypeDbDatastore") -> None: ...

--- a/src/backend/stores/qdrant_store.py
+++ b/src/backend/stores/qdrant_store.py
@@ -1,0 +1,5 @@
+from backend.stores.store import Datastore
+
+
+class QdrantDatastore(Datastore):
+    ...

--- a/src/backend/stores/store.py
+++ b/src/backend/stores/store.py
@@ -1,0 +1,4 @@
+from abc import ABC
+
+class Datastore(ABC):
+    ...

--- a/src/backend/stores/typedb_store.py
+++ b/src/backend/stores/typedb_store.py
@@ -1,0 +1,5 @@
+from backend.stores.store import Datastore
+
+
+class TypeDbDatastore(Datastore):
+    ...


### PR DESCRIPTION
Added an abstract sink which enforces implementation of saving entities to qdrant and typedb, and relations to typedb. It is open to extension in saving to other datastores through overloaded methods.

closes #7 