### PR TITLE
12 database builder write typedb datastore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,7 @@ celerybeat.pid
 
 # Environments
 .env
+.env.*
 .envrc
 .venv
 env/

--- a/pixi.lock
+++ b/pixi.lock
@@ -257,7 +257,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/2a/20/9a227ea57c1285986c4cf78400d0a91615d25b24e257fd9e2969606bdfae/types_requests-2.32.4.20250913-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1f/17/f511b1f91b58787730ad835db96675d922bf2eb8acd625e5004345882c21/whenever-0.9.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: .
+      - pypi: ./
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.9.0-pyh29332c3_0.conda
@@ -505,7 +505,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/2a/20/9a227ea57c1285986c4cf78400d0a91615d25b24e257fd9e2969606bdfae/types_requests-2.32.4.20250913-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/56/65/35de3c29dfe199b37aa409bd3c9e4d3e414a54ac4b9ad71e5c8c51a50f53/whenever-0.9.4-cp312-cp312-macosx_10_12_x86_64.whl
-      - pypi: .
+      - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.9.0-pyh29332c3_0.conda
@@ -752,7 +752,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/2a/20/9a227ea57c1285986c4cf78400d0a91615d25b24e257fd9e2969606bdfae/types_requests-2.32.4.20250913-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c5/4c/b090def9708295dab6942b3e0c703767ef6e60241386187f55101d13edea/whenever-0.9.4-cp312-cp312-macosx_11_0_arm64.whl
-      - pypi: .
+      - pypi: ./
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-2_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
@@ -981,7 +981,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c4/13/e23b2e9b9cf9bba9a108956361cd4429dd6f322468ea57228b4bcbc4cca1/whenever-0.9.4-cp312-cp312-win_amd64.whl
-      - pypi: .
+      - pypi: ./
   development:
     channels:
     - url: https://fast.prefix.dev/conda-forge/
@@ -1239,7 +1239,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/2a/20/9a227ea57c1285986c4cf78400d0a91615d25b24e257fd9e2969606bdfae/types_requests-2.32.4.20250913-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1f/17/f511b1f91b58787730ad835db96675d922bf2eb8acd625e5004345882c21/whenever-0.9.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: .
+      - pypi: ./
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.9.0-pyh29332c3_0.conda
@@ -1487,7 +1487,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/2a/20/9a227ea57c1285986c4cf78400d0a91615d25b24e257fd9e2969606bdfae/types_requests-2.32.4.20250913-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/56/65/35de3c29dfe199b37aa409bd3c9e4d3e414a54ac4b9ad71e5c8c51a50f53/whenever-0.9.4-cp312-cp312-macosx_10_12_x86_64.whl
-      - pypi: .
+      - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.9.0-pyh29332c3_0.conda
@@ -1734,7 +1734,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/2a/20/9a227ea57c1285986c4cf78400d0a91615d25b24e257fd9e2969606bdfae/types_requests-2.32.4.20250913-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c5/4c/b090def9708295dab6942b3e0c703767ef6e60241386187f55101d13edea/whenever-0.9.4-cp312-cp312-macosx_11_0_arm64.whl
-      - pypi: .
+      - pypi: ./
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-2_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
@@ -1963,7 +1963,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c4/13/e23b2e9b9cf9bba9a108956361cd4429dd6f322468ea57228b4bcbc4cca1/whenever-0.9.4-cp312-cp312-win_amd64.whl
-      - pypi: .
+      - pypi: ./
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-3_kmp_llvm.conda
   build_number: 3
@@ -3164,10 +3164,10 @@ packages:
   - pkg:pypi/blis?source=hash-mapping
   size: 3413803
   timestamp: 1729664718220
-- pypi: .
+- pypi: ./
   name: database-builder
   version: 0.1.0
-  sha256: 5132585e24c8e8df99d2f8dc591c57857b9c52e995941585f9053c8d7f5c2d77
+  sha256: 0a83eab7959d51112aa478e648e6a9724f5830516624cc18ffd018a31aff033f
   requires_dist:
   - typedb-driver==2.29.2
   - pyzotero

--- a/pixi.lock
+++ b/pixi.lock
@@ -3167,7 +3167,7 @@ packages:
 - pypi: ./
   name: database-builder
   version: 0.1.0
-  sha256: 0a83eab7959d51112aa478e648e6a9724f5830516624cc18ffd018a31aff033f
+  sha256: 1a712a702f38097a16365a03b0697c5d6179e966e18b7f992b6d29c38e53a803
   requires_dist:
   - typedb-driver==2.29.2
   - pyzotero

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ exclude = [
 ]
 
 [tool.ruff.lint]
-select = ["E4", "E7", "E9", "F", "C4", "PT"]
+select = ["B024", "E4", "E7", "E9", "F", "C4", "PT"]
 
 [tool.ruff]
 exclude = [".pixi", "tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ platforms = ["linux-64", "osx-64", "osx-arm64", "win-64"]
 [tool.pixi.dependencies]
 python = "3.12.*"
 # Dotenv is for reading .env files
-python-dotenv = ">=1.1.0"
+python-dotenv = ">=1.1.0,<2"
 # Async network lib
 anyio = ">=4.9.0"
 # Web framework
@@ -83,7 +83,7 @@ exclude = [
 ]
 
 [tool.ruff.lint]
-select = ["B024", "E4", "E7", "E9", "F", "C4", "PT"]
+select = ["E4", "E7", "E9", "F", "C4", "PT"]
 
 [tool.ruff]
 exclude = [".pixi", "tests"]
@@ -92,6 +92,7 @@ exclude = [".pixi", "tests"]
 lint = "ruff check"
 typecheck = "mypy ."
 test = "pytest -s"
+app = "python -m src.backend.main"
 
 [tool.pixi.activation.env]
 PYTHONNOUSERSITE = "1"

--- a/src/backend/config.py
+++ b/src/backend/config.py
@@ -1,0 +1,18 @@
+import os
+from typing_extensions import Final
+
+from dotenv import load_dotenv, find_dotenv
+
+load_dotenv(find_dotenv('.env'))
+project = os.getenv("project")
+
+project_env = find_dotenv(f'.env.{project.lower()}')
+if project is not None:
+    load_dotenv(project_env, override=True)
+
+class Settings:
+    TYPEDB_URI: Final[str] = os.getenv("TYPEDB_URI")
+    TYPEDB_DATABASE: Final[str] = os.getenv("TYPEDB_DB")
+
+
+settings = Settings()

--- a/src/backend/config.py
+++ b/src/backend/config.py
@@ -6,13 +6,13 @@ from dotenv import load_dotenv, find_dotenv
 load_dotenv(find_dotenv('.env'))
 project = os.getenv("project")
 
-project_env = find_dotenv(f'.env.{project.lower()}')
 if project is not None:
+    project_env = find_dotenv(f'.env.{project.lower()}')
     load_dotenv(project_env, override=True)
 
 class Settings:
-    TYPEDB_URI: Final[str] = os.getenv("TYPEDB_URI")
-    TYPEDB_DATABASE: Final[str] = os.getenv("TYPEDB_DB")
+    TYPEDB_URI: Final[str] = os.getenv("TYPEDB_URI", "localhost:1729")
+    TYPEDB_DATABASE: Final[str] = os.getenv("TYPEDB_DB", "knowledge_platform")
 
 
 settings = Settings()

--- a/src/backend/stores/qdrant_store.py
+++ b/src/backend/stores/qdrant_store.py
@@ -1,5 +1,4 @@
 from backend.stores.store import Datastore
 
-
 class QdrantDatastore(Datastore):
     ...

--- a/src/backend/stores/store.py
+++ b/src/backend/stores/store.py
@@ -1,6 +1,8 @@
 from abc import ABC
 
-class Datastore(ABC):
+
+# 
+class Datastore(ABC):  # noqa: B024
     """
     Abstract base class that should be implemented by datasources to save entities and relations to various datastores.
     Exists for the purpose of typehinting.

--- a/src/backend/stores/store.py
+++ b/src/backend/stores/store.py
@@ -1,7 +1,7 @@
 from abc import ABC
 
 
-# 
+
 class Datastore(ABC):  # noqa: B024
     """
     Abstract base class that should be implemented by datasources to save entities and relations to various datastores.

--- a/src/backend/stores/store.py
+++ b/src/backend/stores/store.py
@@ -1,11 +1,7 @@
-from abc import ABC, abstractmethod
+from abc import ABC
 
 class Datastore(ABC):
-
-    @abstractmethod
-    def connect(self) -> None:
-        pass
-
-    @abstractmethod
-    def save(self, data: dict) -> None:
-        pass
+    """
+    Abstract base class that should be implemented by datasources to save entities and relations to various datastores.
+    Exists for the purpose of typehinting.
+    """

--- a/src/backend/stores/typedb_store.py
+++ b/src/backend/stores/typedb_store.py
@@ -20,6 +20,8 @@ class TypeDbDatastore(Datastore):
         self.typedb_driver: Final[TypeDBDriver] = TypeDB.core_driver(address=settings.TYPEDB_URI)
         self.database: Final[str] = settings.TYPEDB_DATABASE
 
+        assert self.typedb_driver is not None, "TypeDB driver is not initialized."
+        assert self.database is not None, "TypeDB database name is not set."
 
         if not self.typedb_driver.databases.contains(self.database):
             self.typedb_driver.databases.create(self.database)
@@ -34,9 +36,6 @@ class TypeDbDatastore(Datastore):
 
     @contextmanager
     def _query(self, session_type: SessionType, transaction_type: TransactionType):
-        assert self.typedb_driver is not None, "TypeDB driver is not initialized."
-        assert self.database is not None, "TypeDB database name is not set."
-
         session: TypeDBSession
         transaction: TypeDBTransaction
         with self.typedb_driver.session(self.database, session_type) as session:

--- a/src/backend/stores/typedb_store.py
+++ b/src/backend/stores/typedb_store.py
@@ -1,6 +1,6 @@
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Final
+from typing import Any, Final
 from typedb.driver import SessionType, TransactionType, TypeDB, TypeDBDriver, TypeDBOptions, TypeDBSession, TypeDBTransaction
 
 from backend.config import settings
@@ -33,14 +33,14 @@ class TypeDbDatastore(Datastore):
                 transaction.query.define(schema)
 
     @contextmanager
-    def _query(self, session: SessionType, transaction: TransactionType):
+    def _query(self, session_type: SessionType, transaction_type: TransactionType):
         assert self.typedb_driver is not None, "TypeDB driver is not initialized."
         assert self.database is not None, "TypeDB database name is not set."
 
         session: TypeDBSession
         transaction: TypeDBTransaction
-        with self.typedb_driver.session(self.database, session) as session:
-            with session.transaction(transaction) as transaction:
+        with self.typedb_driver.session(self.database, session_type) as session:
+            with session.transaction(transaction_type) as transaction:
                 try:
                     yield transaction
                 finally:
@@ -57,13 +57,13 @@ class TypeDbDatastore(Datastore):
             transaction.query.delete(query, options)
             transaction.commit()
 
-    def fetch(self, query: str, options: TypeDBOptions = None) -> dict:
+    def fetch(self, query: str, options: TypeDBOptions = None) -> list[Any]:
         with self._query(SessionType.DATA, TransactionType.READ) as transaction:
             iterator = transaction.query.fetch(query, options)
             results = [result.map() for result in iterator]
             return results
 
-    def get(self, query: str, options: TypeDBOptions = None) -> dict:
+    def get(self, query: str, options: TypeDBOptions = None) -> list[Any]:
         with self._query(SessionType.DATA, TransactionType.READ) as transaction:
             iterator = transaction.query.get(query, options)
             results = [result.map() for result in iterator]

--- a/src/backend/stores/typedb_store.py
+++ b/src/backend/stores/typedb_store.py
@@ -1,5 +1,75 @@
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Final
+from typedb.driver import SessionType, TransactionType, TypeDB, TypeDBDriver, TypeDBOptions, TypeDBSession, TypeDBTransaction
+
+from backend.config import settings
 from backend.stores.store import Datastore
 
-
 class TypeDbDatastore(Datastore):
-    ...
+    """
+    TypeDbDatastore is a concrete implementation of the Datastore abstract base class for
+    interacting with a TypeDB database.
+
+    Data in TypeDB can be inserted, queried, and managed using TypeDB's schema and query language.
+
+    Due to the implementation of the typedb-driver for TypeDB 2.x this datastore needs separate 
+    methods for inserting, fetching, deleting, and updating data.
+    """
+    def __init__(self) -> None:
+        self.typedb_driver: Final[TypeDBDriver] = TypeDB.core_driver(address=settings.TYPEDB_URI)
+        self.database: Final[str] = settings.TYPEDB_DATABASE
+
+
+        if not self.typedb_driver.databases.contains(self.database):
+            self.typedb_driver.databases.create(self.database)
+
+        current_dir = Path(__file__).parent
+        schema_path = current_dir / 'schema.tql'
+
+        with self._query(SessionType.SCHEMA, TransactionType.WRITE) as transaction:
+            with open(schema_path, 'r', encoding='utf-8') as f:
+                schema = f.read()
+                transaction.query.define(schema)
+
+    @contextmanager
+    def _query(self, session: SessionType, transaction: TransactionType):
+        assert self.typedb_driver is not None, "TypeDB driver is not initialized."
+        assert self.database is not None, "TypeDB database name is not set."
+
+        session: TypeDBSession
+        transaction: TypeDBTransaction
+        with self.typedb_driver.session(self.database, session) as session:
+            with session.transaction(transaction) as transaction:
+                try:
+                    yield transaction
+                finally:
+                    if transaction.is_open() and transaction.transaction_type.is_write():
+                        transaction.commit()
+
+    def save(self, query: str, options: TypeDBOptions = None) -> None:
+        with self._query(SessionType.DATA, TransactionType.WRITE) as transaction:
+            transaction.query.insert(query, options)
+            transaction.commit()
+
+    def delete(self, query: str, options: TypeDBOptions = None) -> None:
+        with self._query(SessionType.DATA, TransactionType.WRITE) as transaction:
+            transaction.query.delete(query, options)
+            transaction.commit()
+
+    def fetch(self, query: str, options: TypeDBOptions = None) -> dict:
+        with self._query(SessionType.DATA, TransactionType.READ) as transaction:
+            iterator = transaction.query.fetch(query, options)
+            results = [result.map() for result in iterator]
+            return results
+
+    def get(self, query: str, options: TypeDBOptions = None) -> dict:
+        with self._query(SessionType.DATA, TransactionType.READ) as transaction:
+            iterator = transaction.query.get(query, options)
+            results = [result.map() for result in iterator]
+            return results
+
+    def update(self, query: str, options: TypeDBOptions = None) -> None:
+        with self._query(SessionType.DATA, TransactionType.WRITE) as transaction:
+            transaction.query.update(query, options)
+            transaction.commit()


### PR DESCRIPTION
This pull request adds a way to interact with the typedb driver in a more user friendly way. 
Developers can now call one of five methods and pass in a query to be executed. This Datastore wrapper handles the sessions, transactions and connection to TypeDB.