### PR TITLE
[hotfix] Fix some of the relation insert logic in typedb_v2 store

### DIFF
--- a/src/database_builder_libs/stores/typedb_v2/typedb_v2_store.py
+++ b/src/database_builder_libs/stores/typedb_v2/typedb_v2_store.py
@@ -229,8 +229,12 @@ class TypeDbDatastore(AbstractStore):
         self.save(query)
 
     def _relation_exists(
-        self, rel_type: str, role_map: Mapping[str, RelationRef]
+        self,
+        rel_type: str,
+        role_map: Mapping[str, RelationRef],
+        attributes: Mapping[str, object] | None = None,
     ) -> bool:
+
         match_roles = []
 
         for role, ref in role_map.items():
@@ -241,16 +245,27 @@ class TypeDbDatastore(AbstractStore):
                 """
             )
 
+        attr_match = ""
+
+        if attributes:
+            attr_match = ", " + self._format_attributes(attributes)
+
         query = f"""
         match
             {"".join(match_roles)}
-            ({", ".join(f"{r}: ${r}" for r in role_map)}) isa {rel_type};
-        get;
+            $r ({", ".join(f"{r}: ${r}" for r in role_map)}) isa {rel_type}
+            {attr_match};
+        get $r;
+        limit 1;
         """
+
         return bool(self.get(query))
 
     def _insert_relation(self, rel: RelationData) -> None:
-        if self._relation_exists(rel["type"], rel["roles"]):
+
+        attributes = rel.get("attributes", {})
+
+        if self._relation_exists(rel["type"], rel["roles"], attributes):
             return
 
         match_roles = []
@@ -265,14 +280,14 @@ class TypeDbDatastore(AbstractStore):
             )
             insert_roles.append(f"{role}: ${role}")
 
-        attrs = self._format_attributes(rel.get("attributes", {}))
+        attrs = self._format_attributes(attributes)
 
         query = f"""
         match
             {"".join(match_roles)}
         insert
             ({", ".join(insert_roles)}) isa {rel["type"]}
-            {", " if attrs else ""}{attrs};
+            {", " + attrs if attrs else ""};
         """
 
         self.save(query)
@@ -477,7 +492,7 @@ class TypeDbDatastore(AbstractStore):
         """
         Load relations for nodes.
 
-        Simpler and safer than complex batch queries.
+        Works with relations of any number of role players.
         """
 
         relations_by_node: dict[str, list[RelationData]] = {}
@@ -487,9 +502,10 @@ class TypeDbDatastore(AbstractStore):
             match
                 $e isa {node.entity_type},
                     has {node.key_attribute} "{node.id}";
-                $r ($role: $e, $other: $x);
-            get $r, $x;
+                $r ($role: $e);
+            get $r;
             """
+
             seen: set[str] = set()
 
             for res in tx.query.get(query):
@@ -511,6 +527,7 @@ class TypeDbDatastore(AbstractStore):
 
                     for player in players:
                         player_type = player.get_type().get_label().name
+
                         key_attr = self._get_key_attr_for_type(player_type)
                         key_val = None
 
@@ -520,6 +537,7 @@ class TypeDbDatastore(AbstractStore):
                                     key_val = attr.get_value()
                                     break
 
+                        # fallback if key attribute unknown
                         if key_val is None:
                             for attr in player.get_has(tx):
                                 key_attr = attr.get_type().get_label().name
@@ -536,6 +554,7 @@ class TypeDbDatastore(AbstractStore):
                             "key_attr": key_attr,
                             "key": str(key_val),
                         }
+
                 attributes: dict[str, object] = {}
 
                 for attr in rel.get_has(tx):
@@ -551,7 +570,6 @@ class TypeDbDatastore(AbstractStore):
                 )
 
         return relations_by_node
-
     def _fetch_to_nodes(
         self, query: str, include_relations: bool = False
     ) -> list[Node]:

--- a/src/database_builder_libs/stores/typedb_v2/typedb_v2_store.py
+++ b/src/database_builder_libs/stores/typedb_v2/typedb_v2_store.py
@@ -209,7 +209,11 @@ class TypeDbDatastore(AbstractStore):
         """
 
         return bool(self.get(query))
-
+    def _match_relation_ref(self, role: str, ref: RelationRef) -> str:
+        return f"""
+            ${role} isa {ref["entity_type"]},
+                has {ref["key_attr"]} "{ref["key"]}";
+        """
     def _insert_entity(
         self,
         entity_type: str,
@@ -235,16 +239,10 @@ class TypeDbDatastore(AbstractStore):
         attributes: Mapping[str, object] | None = None,
     ) -> bool:
 
-        match_roles = []
-
-        for role, ref in role_map.items():
-            match_roles.append(
-                f"""
-                ${role} isa {ref["entity_type"]},
-                    has {ref["key_attr"]} "{ref["key"]}";
-                """
-            )
-
+        match_roles = [
+            self._match_relation_ref(role, ref)
+            for role, ref in role_map.items()
+        ]
         attr_match = ""
 
         if attributes:
@@ -268,17 +266,12 @@ class TypeDbDatastore(AbstractStore):
         if self._relation_exists(rel["type"], rel["roles"], attributes):
             return
 
-        match_roles = []
-        insert_roles = []
+        match_roles = [
+            self._match_relation_ref(role, ref)
+            for role, ref in rel["roles"].items()
+        ]
 
-        for role, ref in rel["roles"].items():
-            match_roles.append(
-                f"""
-                ${role} isa {ref["entity_type"]},
-                    has {ref["key_attr"]} "{ref["key"]}";
-                """
-            )
-            insert_roles.append(f"{role}: ${role}")
+        insert_roles = [f"{role}: ${role}" for role in rel["roles"]]
 
         attrs = self._format_attributes(attributes)
 

--- a/tests/database_builder_libs/stores/test_typedb_store.py
+++ b/tests/database_builder_libs/stores/test_typedb_store.py
@@ -333,63 +333,6 @@ def test_store_node_inserts_relation(store):
     # add schema relation
     with store._query(SessionType.SCHEMA, TransactionType.WRITE) as tx:
         tx.query.define("""
-        friendship sub relation,
-            relates friend,
-            relates friend_of;
-        """)
-
-    store.store_node(alice)
-    store.store_node(bob)
-
-    results = store.get(
-        """
-        match
-            $a isa person, has email "alice@test.com";
-            $b isa person, has email "bob@test.com";
-            (friend: $a, friend_of: $b) isa friendship;
-        get;
-        """
-    )
-
-    assert len(results) == 1
-
-
-def test_store_node_inserts_relation(store):
-    alice = Node(
-        id="alice@test.com",
-        entity_type="person",
-        key_attribute="email",
-        payload_data={"name": "Alice", "email": "alice@test.com", "age": 25},
-        relations=(),
-    )
-
-    bob = Node(
-        id="bob@test.com",
-        entity_type="person",
-        key_attribute="email",
-        payload_data={"name": "Bob", "email": "bob@test.com", "age": 30},
-        relations=(
-            {
-                "type": "friendship",
-                "roles": {
-                    "friend": {
-                        "entity_type": "person",
-                        "key_attr": "email",
-                        "key": "alice@test.com",
-                    },
-                    "friend_of": {
-                        "entity_type": "person",
-                        "key_attr": "email",
-                        "key": "bob@test.com",
-                    },
-                },
-            },
-        ),
-    )
-
-    # add schema relation
-    with store._query(SessionType.SCHEMA, TransactionType.WRITE) as tx:
-        tx.query.define("""
         define
         friendship sub relation,
             relates friend,
@@ -524,3 +467,133 @@ def test_relation_with_attributes(store):
 
     assert rel["type"] == "friendship"
     assert rel["attributes"]["since"] == 2024
+
+
+def test_relation_single_role_player_is_loaded(store):
+    with store._query(SessionType.SCHEMA, TransactionType.WRITE) as tx:
+        tx.query.define("""
+        define
+        tagged sub relation,
+            relates item;
+
+        person plays tagged:item;
+        """)
+
+    store.save("""
+        insert
+            $p isa person, has name "Alice", has email "alice@test.com";
+            (item: $p) isa tagged;
+    """)
+
+    nodes = store.get_nodes("entity=person&email=alice@test.com&include=relations")
+
+    assert len(nodes) == 1
+    node = nodes[0]
+
+    assert len(node.relations) == 1
+    assert node.relations[0]["type"] == "tagged"
+
+def test_relation_attributes_are_loaded(store):
+    with store._query(SessionType.SCHEMA, TransactionType.WRITE) as tx:
+        tx.query.define("""
+        define
+        collaboration sub relation,
+            relates contributor,
+            relates project,
+            owns role;
+
+        role sub attribute, value string;
+
+        person plays collaboration:contributor;
+        person plays collaboration:project;
+        """)
+
+    store.save("""
+        insert
+            $a isa person, has name "Alice", has email "alice@test.com";
+            $b isa person, has name "Bob", has email "bob@test.com";
+            (contributor: $a, project: $b) isa collaboration, has role "author";
+    """)
+
+    nodes = store.get_nodes("entity=person&email=alice@test.com&include=relations")
+
+    rel = nodes[0].relations[0]
+
+    assert rel["attributes"]["role"] == "author"
+
+def test_relations_not_duplicated(store):
+    with store._query(SessionType.SCHEMA, TransactionType.WRITE) as tx:
+        tx.query.define("""
+        define
+        friendship sub relation,
+            relates friend,
+            relates friend_of;
+
+        person plays friendship:friend;
+        person plays friendship:friend_of;
+        """)
+
+    store.save("""
+        insert
+            $a isa person, has name "Alice", has email "alice@test.com";
+            $b isa person, has name "Bob", has email "bob@test.com";
+            (friend: $a, friend_of: $b) isa friendship;
+    """)
+
+    nodes = store.get_nodes("entity=person&email=alice@test.com&include=relations")
+
+    assert len(nodes[0].relations) == 1
+
+def test_store_node_relation_idempotent(store):
+    with store._query(SessionType.SCHEMA, TransactionType.WRITE) as tx:
+        tx.query.define("""
+        define
+        friendship sub relation,
+            relates friend,
+            relates friend_of;
+
+        person plays friendship:friend;
+        person plays friendship:friend_of;
+        """)
+
+    alice = Node(
+        id="alice@test.com",
+        entity_type="person",
+        key_attribute="email",
+        payload_data={"name": "Alice", "email": "alice@test.com"},
+        relations=(),
+    )
+
+    bob = Node(
+        id="bob@test.com",
+        entity_type="person",
+        key_attribute="email",
+        payload_data={"name": "Bob", "email": "bob@test.com"},
+        relations=(
+            {
+                "type": "friendship",
+                "roles": {
+                    "friend": {
+                        "entity_type": "person",
+                        "key_attr": "email",
+                        "key": "alice@test.com",
+                    },
+                    "friend_of": {
+                        "entity_type": "person",
+                        "key_attr": "email",
+                        "key": "bob@test.com",
+                    },
+                },
+            },
+        ),
+    )
+
+    store.store_node(alice)
+    store.store_node(bob)
+
+    # insert again
+    store.store_node(bob)
+
+    nodes = store.get_nodes("entity=person&email=bob@test.com&include=relations")
+
+    assert len(nodes[0].relations) == 1

--- a/tests/database_builder_libs/stores/test_typedb_store.py
+++ b/tests/database_builder_libs/stores/test_typedb_store.py
@@ -545,6 +545,11 @@ def test_relations_not_duplicated(store):
     assert len(nodes[0].relations) == 1
 
 def test_store_node_relation_idempotent(store):
+    """
+    Store the same node again to verify that the operation is idempotent.
+    Re-inserting an existing node should not create duplicates or duplicate relations. 
+    This ensures that calling `store_node` multiple times with the same data leaves the graph in the same state.
+    """
     with store._query(SessionType.SCHEMA, TransactionType.WRITE) as tx:
         tx.query.define("""
         define


### PR DESCRIPTION
# Typedb V2 relation insert logic fix

This PR fixes two issues in the TypeDbDatastore related to relation handling:

- Relation attributes were not always returned by get_nodes.

- Relation existence checks during insertion ignored relation attributes, which caused distinct relations to be incorrectly treated as duplicates.

## Incorrect relation duplication detection

The internal _relation_exists check used during store_node only compared; relation type & role players. But ignored relation attributes...

This meant two relations like:
```
(friend: Alice, friend_of: Bob) isa friendship, has since 2023;
(friend: Alice, friend_of: Bob) isa friendship, has since 2024;
```
were incorrectly considered identical.

## Missing relation attributes in get_nodes

When fetching nodes with include=relations, relation attributes (e.g. since, function) were sometimes not included in the returned Node.relations structure.

This happened because the relation loading query did not properly collect attributes associated with the relation instance.

## Autogenerated

This pull request enhances the Typedb v2 store by improving how relations are handled, particularly with support for relation attributes, single-role-player relations, and ensuring idempotency and correctness when inserting and loading relations. It also expands the test suite to cover these scenarios.

**Typedb relation handling improvements:**

* The `_relation_exists` and `_insert_relation` methods in `typedb_v2_store.py` now support checking and inserting relations with attributes, ensuring that relations are not duplicated if their attributes match. [[1]](diffhunk://#diff-9a656734c22c08bad738f0c6996d93f84bed89983e8019391a985e5acaa6e84eL232-R237) [[2]](diffhunk://#diff-9a656734c22c08bad738f0c6996d93f84bed89983e8019391a985e5acaa6e84eR248-R268) [[3]](diffhunk://#diff-9a656734c22c08bad738f0c6996d93f84bed89983e8019391a985e5acaa6e84eL268-R290)
* The `_load_relations_batch` method is updated to work with relations having any number of role players (including single-role relations), and to correctly load relation attributes. [[1]](diffhunk://#diff-9a656734c22c08bad738f0c6996d93f84bed89983e8019391a985e5acaa6e84eL480-R495) [[2]](diffhunk://#diff-9a656734c22c08bad738f0c6996d93f84bed89983e8019391a985e5acaa6e84eL490-R508) [[3]](diffhunk://#diff-9a656734c22c08bad738f0c6996d93f84bed89983e8019391a985e5acaa6e84eR530) [[4]](diffhunk://#diff-9a656734c22c08bad738f0c6996d93f84bed89983e8019391a985e5acaa6e84eR540) [[5]](diffhunk://#diff-9a656734c22c08bad738f0c6996d93f84bed89983e8019391a985e5acaa6e84eR557) [[6]](diffhunk://#diff-9a656734c22c08bad738f0c6996d93f84bed89983e8019391a985e5acaa6e84eL554)

**Testing enhancements:**

* New tests are added to verify that:
  - Relations with a single role player are correctly loaded.
  - Relation attributes are properly loaded and matched.
  - Relations are not duplicated on repeated inserts (idempotency).
* The existing relation insertion test is cleaned up for clarity.

These changes make the Typedb store more robust when dealing with complex relation structures and ensure correctness in both the code and its tests.