### PR TITLE
Move the generic pdf file metadata extraction class from SCEPA project to database builder libs

### DIFF
--- a/docs/getting_started/02_examples.md
+++ b/docs/getting_started/02_examples.md
@@ -5,6 +5,7 @@ This page provides practical examples of how to use the database-builder-libs li
 ## Table of Contents
 
 - [Working with Zotero Source](#working-with-zotero-source)
+- [Working with PDF Source](#working-with-pdf-source)
 - [Document Parsing](#document-parsing)
 - [Chunking Strategies](#chunking-strategies)
 - [Using Vector Stores (Qdrant)](#using-vector-stores-qdrant)
@@ -88,6 +89,202 @@ for doc in documents:
     print(f"Document: {doc.get('data', {}).get('title', 'No title')}")
     print(f"Key: {doc.get('data', {}).get('key', 'No key')}")
     print("---")
+```
+
+## Working with PDF Source
+
+The PDF source parses PDF files from a local folder, extracts metadata, chunks the content into
+sections, and optionally embeds those chunks — all in a single configurable pipeline.
+
+### Minimal setup
+
+Only `folder_path` is required. With no further config, metadata is extracted from embedded PDF
+metadata and Docling structural heuristics. No LLM calls are made.
+
+```python
+from database_builder_libs.sources.pdf_source import PDFSource
+
+src = PDFSource()
+src.connect({"folder_path": "/data/papers"})
+```
+
+### Listing changed files
+
+`get_list_artefacts` scans the folder for PDFs modified after `last_synced`. Pass `None` to
+return every file.
+
+```python
+from datetime import datetime, timezone
+
+last_sync = datetime(2024, 1, 1, tzinfo=timezone.utc)
+artefacts = src.get_list_artefacts(last_sync)
+
+for relative_path, modified_at in artefacts:
+    print(f"{relative_path}  —  last modified {modified_at}")
+```
+
+### Extracting content
+
+`get_content` runs the full pipeline — parse, metadata extraction, chunking, embedding — and
+returns one `Content` object per file.
+
+```python
+contents = src.get_content(artefacts)
+
+for content in contents:
+    meta = content.content["metadata"]
+    print(f"File:    {content.content['file_name']}")
+    print(f"Title:   {meta['title']}")
+    print(f"Authors: {meta['authors']}")
+    print(f"Source:  {meta['source']}")   # which strategy filled each field
+    print(f"Chunks:  {len(content.content['chunks'])}")
+    print("---")
+```
+
+### Enabling LLM extraction
+
+Provide `llm_base_url` and `llm_api_key` to unlock LLM-based extraction for fields where
+heuristics are insufficient — typically `title` on watermarked PDFs, `authors` on
+Word-derived documents, and `acknowledgements`.
+
+```python
+src = PDFSource()
+src.connect({
+    "folder_path":  "/data/papers",
+    "llm_base_url": "http://localhost:11434/v1",
+    "llm_api_key":  "ollama",
+    "llm_model":    "gemma2:9b",
+})
+```
+
+Any OpenAI-compatible endpoint works. The default model is `gpt-4.1-mini`.
+
+### Configuring extraction strategies per field
+
+Each metadata field can be configured independently. Strategies are tried in order;
+extraction stops on the first success unless `stop_on_success=False`.
+
+```python
+from database_builder_libs.sources.pdf_source import (
+    PDFSource,
+    FieldExtractionConfig,
+    OrderedStrategyConfig,
+    ExtractionStrategy,
+)
+
+src = PDFSource()
+src.connect({
+    "folder_path":  "/data/papers",
+    "llm_base_url": "http://localhost:11434/v1",
+    "llm_api_key":  "ollama",
+
+    # Try LLM first for title; fall back to Docling if LLM returns nothing.
+    "title": FieldExtractionConfig(
+        strategies=OrderedStrategyConfig(
+            order=[ExtractionStrategy.LLM, ExtractionStrategy.DOCLING],
+        )
+    ),
+
+    # Run both FILE_METADATA and LLM regardless of success — LLM always
+    # overwrites the embedded metadata value, which is often the Word creator name.
+    "authors": FieldExtractionConfig(
+        strategies=OrderedStrategyConfig(
+            order=[ExtractionStrategy.FILE_METADATA, ExtractionStrategy.LLM],
+            stop_on_success=False,
+        )
+    ),
+
+    # Disable acknowledgement extraction entirely.
+    "acknowledgements": FieldExtractionConfig(enabled=False),
+})
+```
+
+### Skipping fields already known from an external source
+
+When metadata is already available from a source like Zotero, disable the corresponding
+PDF extraction fields with `enabled=False`. Omitting a field from the config is not
+enough — `PDFDocumentConfig` has defaults for every field and will extract silently
+if not explicitly disabled.
+
+```python
+src = PDFSource()
+src.connect({
+    "folder_path": "/data/papers",
+    "title":       FieldExtractionConfig(enabled=False),  # already known
+    "authors":     FieldExtractionConfig(enabled=False),  # already known
+    # summary, publishing_institute, acknowledgements use their defaults
+})
+```
+
+After `get_content`, overlay the externally known values onto the returned `Content`:
+
+```python
+content = src.get_content(artefacts)[0]
+meta    = content.content["metadata"]
+source  = meta.get("source", {})
+
+# Overlay values from an external source
+meta["title"]   = "Title from Zotero"
+meta["authors"] = ["Author A", "Author B"]
+source["title"]   = "zotero"
+source["authors"] = "zotero"
+meta["source"]  = source
+```
+
+### Adding chunking and embedding
+
+Pass a `SectionsConfig` to control how sections are chunked and embedded.
+
+```python
+from database_builder_libs.sources.pdf_source import SectionsConfig
+from database_builder_libs.utility.chunk.summary_and_sections import SummaryAndSectionsStrategy
+from database_builder_libs.utility.embed_chunk.openai_compatible import OpenAICompatibleChunkEmbedder
+
+src = PDFSource()
+src.connect({
+    "folder_path": "/data/papers",
+    "sections": SectionsConfig(
+        chunking_strategy=SummaryAndSectionsStrategy(),
+        embedder=OpenAICompatibleChunkEmbedder(
+            base_url="http://localhost:11434/v1",
+            api_key="ollama",
+            model="nomic-embed-text",
+        ),
+    ),
+})
+
+contents = src.get_content(artefacts)
+for content in contents:
+    for chunk in content.content["chunks"]:
+        print(chunk["chunk_index"], chunk["text"][:80])
+```
+
+To skip chunking and embedding entirely and only extract metadata:
+
+```python
+src.connect({
+    "folder_path": "/data/papers",
+    "sections": SectionsConfig(enabled=False),
+})
+```
+
+### Quick inventory without parsing
+
+`get_all_documents_metadata` returns lightweight file stats for all PDFs in the folder
+without running Docling conversion — useful for auditing or building a manifest.
+
+```python
+inventory = src.get_all_documents_metadata()
+
+for item in inventory:
+    print(f"{item['id']}  {item['size']} bytes  modified {item['modified']}")
+    print(f"  pdf_meta: {item['pdf_meta']}")
+```
+
+Pass `limit` to cap the number of results:
+
+```python
+first_ten = src.get_all_documents_metadata(limit=10)
 ```
 
 ## Document Parsing
@@ -292,6 +489,7 @@ fixed-size for the same input. The overlap means the end of chunk *N* and the st
 of chunk *N+1* share words, which improves recall for queries that land near a boundary.
 
 ### Summary + sections chunking
+
 Preserves the document's natural section structure and optionally prepends a dedicated
 summary chunk at index 0. This is the right choice when section-level retrieval
 granularity must be maintained and an optional LLM-generated summary is desired.
@@ -335,7 +533,7 @@ for chunk in body_chunks:
 | `SectionChunkingStrategy` | One per section | Clean heading structure, variable section length is acceptable |
 | `FixedSizeChunkingStrategy` | One or more per section | Uniform context window needed, no overlap required |
 | `SlidingWindowChunkingStrategy` | More than fixed-size due to overlap | Boundary recall matters; willing to trade storage for coverage |
-| `SummaryAndSectionsStrategy` | One per section (+ 1 if summary provided) | Section structure must be preserved with an optional summary chunk prepended|
+| `SummaryAndSectionsStrategy` | One per section (+ 1 if summary provided) | Section structure must be preserved with an optional summary chunk prepended |
 
 ### Common chunk fields
 
@@ -389,7 +587,6 @@ chunks = [
         vector=[0.2, 0.3, ...],
         metadata={"page": 1, "section": "introduction"}
     ),
-    # Add more chunks as needed
 ]
 
 # Store the chunks
@@ -528,7 +725,7 @@ if person_nodes:
     print(f"Found person: {person.payload_data.get('name')}")
     print(f"Email: {person.payload_data.get('email')}")
     print(f"Age: {person.payload_data.get('age')}")
-    
+
     # Print relations
     for relation in person.relations:
         print(f"Relation: {relation.get('type')} -> {relation.get('target')}")

--- a/docs/main_modules/12_pdf_source.md
+++ b/docs/main_modules/12_pdf_source.md
@@ -1,0 +1,231 @@
+# PDF source
+
+## Overview
+
+The PDF source allows you to parse, extract metadata from, chunk, and embed PDF documents stored in a local folder. It implements the AbstractSource interface to provide incremental synchronization based on file modification times, and exposes a fully configurable extraction pipeline that can combine embedded PDF metadata, structural heuristics from Docling, and LLM-based extraction for each metadata field independently.
+
+## Design Notes
+
+### Interaction Patterns
+
+The PDFSource follows these interaction patterns:
+
+1. **Connection Pattern**:
+    - Validate folder path exists on disk
+    - Initialise the Docling document parser
+    - Build the LLM client if credentials are provided
+    - All field extraction strategies are configured at connect time
+
+2. **Synchronization Pattern**:
+    - Scan folder recursively for `.pdf` files
+    - Compare file mtime against `last_synced` cursor
+    - Return stable relative paths as artefact identifiers
+    - Sorted ascending by mtime for deterministic ordering
+
+3. **Content Retrieval Pattern**:
+    - Parse each PDF with Docling to produce a structural IR
+    - Run the metadata extraction pipeline (see Configuration below)
+    - Chunk the parsed sections using the configured strategy
+    - Embed chunks if an embedder is configured
+    - Pack everything into a `Content` object
+
+4. **Metadata Extraction Pattern**:
+    - Each field (`title`, `authors`, `summary`, `publishing_institute`, `acknowledgements`) has its own ordered strategy list
+    - Strategies are tried in order; extraction stops on first success when `stop_on_success=True`
+    - Expensive operations (LLM call, PDF metadata read) are cached and run at most once per document
+
+### Implementation Details
+
+* **Incremental Sync**: Uses filesystem mtime for change detection. Deletions are not reported.
+* **Stable Identifiers**: Artefact IDs are paths relative to `folder_path` and remain stable as long as files are not moved.
+* **Parser Resilience**: Docling conversion failures are caught and logged per file; the pipeline continues and returns a `Content` with empty chunks and metadata for that file.
+* **LLM Caching**: The LLM is called at most once per document regardless of how many fields request it. The result is cached and reused across fields.
+* **PDF Metadata Robustness**: The embedded PDF metadata reader handles both plain dicts and `DocumentInformation` objects (pypdf), as well as gracefully dropping any non-string keys caused by library version mismatches.
+* **Chunking**: Sections produced by Docling are passed to the configured `AbstractChunkingStrategy`. Chunking failures are caught and logged without aborting the pipeline.
+* **Embedding**: If an `AbstractChunkEmbedder` is configured, it is called on the chunk list after chunking. Embedding failures return the original un-embedded chunks.
+
+## Configuring the PDFSource
+
+Configuration is passed as a dict to `src.connect({...})` and validated into a `PDFDocumentConfig` internally. All keys except `folder_path` are optional.
+
+### Minimal setup
+
+Only `folder_path` is required. With no other config, metadata extraction uses embedded PDF metadata and Docling heuristics only — no LLM calls are made.
+
+```python
+src = PDFSource()
+src.connect({"folder_path": "/data/papers"})
+```
+
+### Enabling LLM extraction
+
+Provide `llm_base_url`, `llm_api_key`, and optionally `llm_model` to enable LLM-based extraction. The LLM receives the first 60 lines of the document and is expected to return JSON with `title`, `authors`, `publishing_institute`, and `acknowledgements`.
+
+```python
+src = PDFSource()
+src.connect({
+    "folder_path":  "/data/papers",
+    "llm_base_url": "http://localhost:11434/v1",
+    "llm_api_key":  "ollama",
+    "llm_model":    "gemma2:9b",
+})
+```
+
+Any OpenAI-compatible endpoint is supported. The default model is `gpt-4.1-mini`.
+
+### Configuring extraction strategies per field
+
+Each metadata field can be configured independently using a `FieldExtractionConfig` that holds an `OrderedStrategyConfig`. The three available strategies are:
+
+| Strategy | Key | Description |
+|---|---|---|
+| `ExtractionStrategy.FILE_METADATA` | `"file_metadata"` | Reads embedded PDF metadata via pypdf. Fast, no ML. Reliable for well-tagged PDFs; often noisy for Word-derived documents. |
+| `ExtractionStrategy.DOCLING` | `"docling"` | Infers values from the Docling structural IR. Uses section headers for title, abstract section detection for summary. |
+| `ExtractionStrategy.LLM` | `"llm"` | Sends the document header to the configured LLM. Most flexible but requires LLM credentials and adds latency. |
+
+The `OrderedStrategyConfig` controls the order strategies are tried and whether to stop on the first success:
+
+```python
+from database_builder_libs.sources.pdf_source import (
+    FieldExtractionConfig,
+    OrderedStrategyConfig,
+    ExtractionStrategy,
+)
+
+# Try LLM first, fall back to Docling heuristics
+title_config = FieldExtractionConfig(
+    strategies=OrderedStrategyConfig(
+        order=[ExtractionStrategy.LLM, ExtractionStrategy.DOCLING],
+        stop_on_success=True,   # default — stops as soon as one strategy succeeds
+    )
+)
+
+# Run both strategies regardless of success — LLM overwrites FILE_METADATA result
+authors_config = FieldExtractionConfig(
+    strategies=OrderedStrategyConfig(
+        order=[ExtractionStrategy.FILE_METADATA, ExtractionStrategy.LLM],
+        stop_on_success=False,  # LLM always runs and overwrites
+    )
+)
+
+# Disable a field entirely
+acks_config = FieldExtractionConfig(enabled=False)
+```
+
+Pass these configs by field name in the connect dict:
+
+```python
+src.connect({
+    "folder_path":          "/data/papers",
+    "llm_base_url":         "http://localhost:11434/v1",
+    "llm_api_key":          "ollama",
+    "title":                title_config,
+    "authors":              authors_config,
+    "acknowledgements":     acks_config,
+})
+```
+
+### Default extraction strategies
+
+When no field config is provided, PDFSource uses these defaults:
+
+| Field | Default strategy order | Notes |
+|---|---|---|
+| `title` | `FILE_METADATA` → `DOCLING` | LLM not in default chain; add it if embedded metadata is unreliable |
+| `authors` | `FILE_METADATA` → `LLM` | LLM used as fallback when embedded metadata is empty or noisy |
+| `summary` | `DOCLING` | Abstract section detection is reliable; LLM rarely needed |
+| `publishing_institute` | `FILE_METADATA` | LLM can be added for documents without well-tagged metadata |
+| `acknowledgements` | `LLM` | Only LLM can extract these reliably from free text |
+
+### Configuring chunking and embedding
+
+Section chunking and vector embedding are controlled via `SectionsConfig`. Disable chunking entirely, or plug in any `AbstractChunkingStrategy` and `AbstractChunkEmbedder` implementation.
+
+```python
+from database_builder_libs.sources.pdf_source import SectionsConfig
+from database_builder_libs.utility.chunk.summary_and_sections import SummaryAndSectionsStrategy
+from database_builder_libs.utility.embed_chunk.openai_compatible import OpenAICompatibleChunkEmbedder
+
+src.connect({
+    "folder_path": "/data/papers",
+    "sections": SectionsConfig(
+        chunking_strategy=SummaryAndSectionsStrategy(),
+        embedder=OpenAICompatibleChunkEmbedder(
+            base_url="http://localhost:11434/v1",
+            api_key="ollama",
+            model="nomic-embed-text",
+        ),
+    ),
+})
+```
+
+To skip chunking and embedding entirely (metadata and file stats only):
+
+```python
+src.connect({
+    "folder_path": "/data/papers",
+    "sections": SectionsConfig(enabled=False),
+})
+```
+
+### Skipping fields already known from an external source
+
+When metadata for a document is already available from an external source (e.g. Zotero), pass `FieldExtractionConfig(enabled=False)` explicitly for those fields. Omitting a field from the config is not sufficient — PDFDocumentConfig has defaults for every field and will fall back to them silently.
+
+```python
+src.connect({
+    "folder_path": "/data/papers",
+    "title":   FieldExtractionConfig(enabled=False),  # already known from Zotero
+    "authors": FieldExtractionConfig(enabled=False),  # already known from Zotero
+    # summary, publishing_institute and acknowledgements will use their defaults
+})
+```
+
+## Content object structure
+
+`PDFSource.get_content()` returns one `Content` object per artefact. `Content.content` is a dict with the following keys:
+
+| Key | Type | Description |
+|---|---|---|
+| `file_path` | `str` | Absolute path to the PDF file |
+| `file_name` | `str` | Filename only |
+| `file_size` | `int` | File size in bytes |
+| `num_pages` | `int \| None` | Page count from Docling; `None` if conversion failed |
+| `pdf_meta` | `dict` | Raw embedded PDF metadata from pypdf, keys stripped of leading `/` |
+| `metadata` | `dict` | `DocumentMetadata` serialised via `dataclasses.asdict()` |
+| `num_sections` | `int` | Section count from Docling |
+| `num_tables` | `int` | Table count from Docling |
+| `num_figures` | `int` | Figure count from Docling |
+| `section_titles` | `list[str]` | Ordered list of section header strings |
+| `chunks` | `list[dict]` | `Chunk` objects serialised via `dataclasses.asdict()` |
+
+The `metadata` dict mirrors `DocumentMetadata` and includes a `source` sub-dict that maps each populated field to the strategy that filled it, for example:
+
+```json
+{
+  "title": "A Randomised Controlled Trial ...",
+  "authors": ["Heyman, Bob", "Harrington, Barbara"],
+  "publishing_institute": {"name": "Housing Studies", "parent": null},
+  "summary": "This paper discusses ...",
+  "acknowledgements": [
+    {"name": "NEARG", "type": "organization", "relation": "collaboration"}
+  ],
+  "source": {
+    "title": "zotero",
+    "authors": "zotero",
+    "summary": "docling_heuristic",
+    "publishing_institute": "llm",
+    "acknowledgements": "llm"
+  },
+  "keywords": null,
+  "literature_type": null,
+  "strategic_overview": null,
+  "target_groups": null,
+  "best_practices": null
+}
+```
+
+## Docstring
+
+::: database_builder_libs.sources.pdf_source
+    handler: python

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -149,6 +149,7 @@ nav:
   - Sources:
     - main_modules/01_abstract_source.md
     - main_modules/04_zotero_source.md
+    - main_modules/12_pdf_source.md
   - Graph Stores:
     - main_modules/02_stores.md
     - main_modules/05_typedb_v2_store.md

--- a/src/database_builder_libs/models/abstract_vector_store.py
+++ b/src/database_builder_libs/models/abstract_vector_store.py
@@ -23,7 +23,7 @@ class AbstractVectorStore(ABC):
     - Deterministic retrieval for identical index state
     - No duplicate chunks returned
     - Stable chunk identity across writes
-    - Full deletion of document vectors (GDPR requirement)
+    - Full deletion of document vectors (GPDR requirement)
 
     Embedding contract
     ------------------

--- a/src/database_builder_libs/models/abstract_vector_store.py
+++ b/src/database_builder_libs/models/abstract_vector_store.py
@@ -23,7 +23,7 @@ class AbstractVectorStore(ABC):
     - Deterministic retrieval for identical index state
     - No duplicate chunks returned
     - Stable chunk identity across writes
-    - Full deletion of document vectors (GPDR requirement)
+    - Full deletion of document vectors (GDPR requirement)
 
     Embedding contract
     ------------------

--- a/src/database_builder_libs/sources/pdf_source.py
+++ b/src/database_builder_libs/sources/pdf_source.py
@@ -1,0 +1,638 @@
+from __future__ import annotations
+
+import dataclasses
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional
+
+from enum import Enum
+from loguru import logger
+from pydantic import BaseModel, Field, PrivateAttr, field_validator
+from pypdf import PdfReader
+
+from database_builder_libs.models.abstract_source import AbstractSource, Content
+from database_builder_libs.models.abstract_chunk_embedder import AbstractChunkEmbedder
+from database_builder_libs.models.abstract_chunk_strategy import AbstractChunkingStrategy, RawSection
+from database_builder_libs.models.chunk import Chunk
+from database_builder_libs.utility.chunk.n_points_section import SectionChunkingStrategy
+from database_builder_libs.utility.extract.document_parser_docling import (
+    DocumentConversionError,
+    DocumentParserDocling,
+    ParsedDocument,
+)
+
+
+class ExtractionStrategy(str, Enum):
+    DOCLING = "docling"
+    LLM = "llm"
+    FILE_METADATA = "file_metadata"
+
+
+class StrategyConfig(BaseModel):
+    timeout: Optional[int] = None
+    confidence_threshold: Optional[float] = None
+
+
+class OrderedStrategyConfig(BaseModel):
+    order: List[ExtractionStrategy] = Field(default_factory=list)
+    stop_on_success: bool = True
+    configs: Dict[ExtractionStrategy, StrategyConfig] = Field(default_factory=dict)
+
+    @field_validator("order")
+    def no_duplicates(cls, v: list) -> list:
+        if len(v) != len(set(v)):
+            raise ValueError("Duplicate strategies in order")
+        return v
+
+
+class FieldExtractionConfig(BaseModel):
+    enabled: bool = True
+    strategies: OrderedStrategyConfig = Field(default_factory=OrderedStrategyConfig)
+
+
+class SectionsConfig(BaseModel):
+    """
+    Controls section extraction, chunking, and optional embedding.
+
+    Attributes
+    ----------
+    enabled : bool
+        When ``False`` no chunks are produced and ``Content.content["chunks"]``
+        will be an empty list.
+    chunking_strategy : AbstractChunkingStrategy
+        Strategy used to convert ``ParsedDocument.sections`` into ``Chunk``
+        objects.  Defaults to :class:`SectionChunkingStrategy` (one chunk per
+        section).
+    embedder : AbstractChunkEmbedder | None
+        When provided, its ``embed()`` method is called on the produced chunks
+        to populate their ``vector`` fields before assembly.  When ``None``
+        chunks are returned with empty vectors.
+    """
+
+    enabled: bool = True
+    chunking_strategy: AbstractChunkingStrategy = Field(
+        default_factory=SectionChunkingStrategy
+    )
+    embedder: Optional[AbstractChunkEmbedder] = None
+
+    model_config = {"arbitrary_types_allowed": True}
+
+
+class PDFDocumentConfig(BaseModel):
+    """
+    Configuration for the PDF source pipeline.
+ 
+    Each ``FieldExtractionConfig`` controls which extraction engines are tried
+    for that metadata field, in order, stopping on first success when
+    ``stop_on_success`` is ``True``.
+ 
+    Attributes
+    ----------
+    folder_path : Path
+        Root directory scanned recursively for ``*.pdf`` files.
+    title, authors, authors_institute, summary, abstract,
+    publishing_institute, acknowledgements : FieldExtractionConfig
+        Per-field extraction configuration with ordered strategy lists.
+    sections : SectionsConfig
+        Controls section extraction, chunking strategy, and optional embedding.
+ 
+    Usage
+    -----
+    **Minimal — defaults only**
+ 
+    The simplest valid config only requires ``folder_path``.  All metadata
+    fields use their built-in strategy defaults and sections are extracted
+    with one chunk per section, no embedding::
+ 
+        config = PDFDocumentConfig(folder_path=Path("/data/papers"))
+ 
+    **Connecting PDFSource**
+ 
+    Pass the config as a plain dict to ``PDFSource.connect()``::
+ 
+        src = PDFSource()
+        src.connect({
+            "folder_path": "/data/papers",
+        })
+ 
+    **Customising metadata extraction strategies**
+ 
+    Each metadata field accepts an ``enabled`` flag and an ordered list of
+    ``ExtractionStrategy`` values.  The pipeline tries each strategy in order
+    and stops on the first that produces a result (``stop_on_success=True``).
+ 
+    Available strategies:
+ 
+    - ``ExtractionStrategy.FILE_METADATA`` — reads embedded PDF metadata via
+      ``pypdf`` (fast, no ML required).
+    - ``ExtractionStrategy.DOCLING`` — uses Docling's structural extraction
+      (section headers, abstract detection).
+    - ``ExtractionStrategy.LLM`` — sends the first page to an LLM for
+      extraction (requires ``OPENAI_API_KEY`` in the environment).
+ 
+    Example — use only ``FILE_METADATA`` for title, disable
+    ``authors_institute`` entirely, and try ``DOCLING`` then ``LLM`` for
+    summary::
+ 
+        config = PDFDocumentConfig(
+            folder_path=Path("/data/papers"),
+            title=FieldExtractionConfig(
+                strategies=OrderedStrategyConfig(
+                    order=[ExtractionStrategy.FILE_METADATA],
+                )
+            ),
+            authors_institute=FieldExtractionConfig(enabled=False),
+            summary=FieldExtractionConfig(
+                strategies=OrderedStrategyConfig(
+                    order=[ExtractionStrategy.DOCLING, ExtractionStrategy.LLM],
+                    stop_on_success=True,
+                )
+            ),
+        )
+ 
+    **Customising chunking strategy**
+ 
+    Supply any ``AbstractChunkingStrategy`` implementation via
+    ``SectionsConfig.chunking_strategy``.  The default is
+    ``SectionChunkingStrategy`` (one chunk per Docling section).
+ 
+    Switch to fixed-size windows of 800 characters::
+ 
+        from database_builder_libs.utility.chunk.n_points_fixed_size import (
+            FixedSizeChunkingStrategy,
+        )
+ 
+        config = PDFDocumentConfig(
+            folder_path=Path("/data/papers"),
+            sections=SectionsConfig(
+                chunking_strategy=FixedSizeChunkingStrategy(chunk_size=800),
+            ),
+        )
+ 
+    Use the summary-and-sections strategy (prepends an abstract chunk, then
+    splits the rest into 5 evenly-sized body chunks)::
+ 
+        from database_builder_libs.utility.chunk.summary_and_sections import (
+            SummaryAndSectionsStrategy,
+        )
+ 
+        config = PDFDocumentConfig(
+            folder_path=Path("/data/papers"),
+            sections=SectionsConfig(
+                chunking_strategy=SummaryAndSectionsStrategy(min_chars=30),
+            ),
+        )
+ 
+    **Adding an embedder**
+ 
+    Attach any ``AbstractChunkEmbedder`` to ``SectionsConfig.embedder``.
+    Chunks are embedded in a single batched call immediately after chunking.
+ 
+    OpenAI-compatible endpoint (e.g. Ollama running locally)::
+ 
+        from database_builder_libs.utility.embed_chunk.openai_compatible import (
+            OpenAICompatibleChunkEmbedder,
+        )
+ 
+        config = PDFDocumentConfig(
+            folder_path=Path("/data/papers"),
+            sections=SectionsConfig(
+                chunking_strategy=SectionChunkingStrategy(),
+                embedder=OpenAICompatibleChunkEmbedder(
+                    base_url="http://localhost:11434/v1",
+                    api_key="ollama",
+                    model="nomic-embed-text",
+                ),
+            ),
+        )
+ 
+    Local HuggingFace transformer model::
+ 
+        from database_builder_libs.utility.embed_chunk.transformer_based import (
+            TransformersChunkEmbedder,
+        )
+ 
+        config = PDFDocumentConfig(
+            folder_path=Path("/data/papers"),
+            sections=SectionsConfig(
+                embedder=TransformersChunkEmbedder(
+                    model_name_or_path="sentence-transformers/all-MiniLM-L6-v2",
+                    batch_size=64,
+                ),
+            ),
+        )
+ 
+    **Disabling section extraction**
+ 
+    Set ``sections.enabled = False`` to skip chunking entirely.  The
+    ``Content.content["chunks"]`` list will be empty but all other metadata
+    fields are still extracted::
+ 
+        config = PDFDocumentConfig(
+            folder_path=Path("/data/papers"),
+            sections=SectionsConfig(enabled=False),
+        )
+    """
+ 
+    folder_path: Path
+ 
+    title: FieldExtractionConfig = Field(default_factory=FieldExtractionConfig)
+ 
+    authors: FieldExtractionConfig = Field(
+        default_factory=lambda: FieldExtractionConfig(
+            strategies=OrderedStrategyConfig(
+                order=[ExtractionStrategy.FILE_METADATA, ExtractionStrategy.LLM]
+            )
+        )
+    )
+ 
+    authors_institute: FieldExtractionConfig = Field(default_factory=FieldExtractionConfig)
+ 
+    summary: FieldExtractionConfig = Field(
+        default_factory=lambda: FieldExtractionConfig(
+            strategies=OrderedStrategyConfig(
+                order=[ExtractionStrategy.DOCLING, ExtractionStrategy.LLM]
+            )
+        )
+    )
+ 
+    abstract: FieldExtractionConfig = Field(
+        default_factory=lambda: FieldExtractionConfig(
+            strategies=OrderedStrategyConfig(
+                order=[ExtractionStrategy.DOCLING, ExtractionStrategy.LLM]
+            )
+        )
+    )
+ 
+    publishing_institute: FieldExtractionConfig = Field(default_factory=FieldExtractionConfig)
+    acknowledgements: FieldExtractionConfig = Field(default_factory=FieldExtractionConfig)
+    sections: SectionsConfig = Field(default_factory=SectionsConfig)
+ 
+ 
+
+class PDFSource(AbstractSource):
+    """
+    PDF document source implementation of AbstractSource.
+
+    Provides incremental synchronisation of a folder of PDF files and exposes
+    each file as a canonical ``Content`` object containing extracted metadata,
+    structured sections, and optionally embedded ``Chunk`` objects.
+
+    Mapping
+    -------
+    PDF file path (relative)  →  Content.id_
+    File mtime (UTC)          →  Content.date
+    Extracted payload         →  Content.content
+
+    Content.content keys
+    --------------------
+    ``file_path``   – absolute path on disk
+    ``file_name``   – basename
+    ``file_size``   – bytes
+    ``num_pages``   – page count from pypdf (``None`` on read error)
+    ``pdf_meta``    – raw embedded PDF metadata dict from pypdf
+    ``sections``    – list of ``(title, text, tables)`` dicts from Docling
+    ``chunks``      – list of serialised ``Chunk`` dicts, ready for indexing
+
+    Synchronisation semantics
+    -------------------------
+    - ``get_list_artefacts()`` performs incremental sync using file-system mtime.
+    - Files with ``mtime > last_synced`` are returned; deletions are not reported.
+    - Returned timestamps are timezone-aware UTC.
+    - Identifiers (relative paths) are stable across runs as long as files are
+      not renamed or moved.
+
+    Lifecycle
+    ---------
+    ``connect()`` must be called before any other method.
+    """
+
+    _config: Optional[PDFDocumentConfig] = PrivateAttr(default=None)
+    _parser: Optional[DocumentParserDocling] = PrivateAttr(default=None)
+
+    def _connect_impl(self, config: Mapping[str, Any]) -> None:
+        """
+        Validate config and initialise the Docling parser.
+
+        Parameters
+        ----------
+        config : Mapping[str, Any]
+            Must contain at least ``folder_path`` pointing to an existing
+            directory.  All other keys map to ``PDFDocumentConfig`` fields.
+
+        Raises
+        ------
+        ValueError
+            If ``folder_path`` does not exist or is not a directory.
+        """
+        self._config = PDFDocumentConfig(**config)
+        if not self._config.folder_path.is_dir():
+            raise ValueError(
+                f"folder_path '{self._config.folder_path}' does not exist or is not a directory."
+            )
+        self._parser = DocumentParserDocling()
+        logger.info(f"PDFSource connected to folder: {self._config.folder_path}")
+
+    def get_all_documents_metadata(self, limit: int = -1) -> List[dict[str, Any]]:
+        """
+        Retrieve file-level metadata for all PDFs in the configured folder.
+
+        Recursively scans ``folder_path`` for ``*.pdf`` files and reads their
+        embedded PDF metadata via ``pypdf``.  No Docling conversion is
+        performed; this method is intended for quick inventory purposes.
+
+        Parameters
+        ----------
+        limit : int, optional
+            Maximum number of documents to return.  ``-1`` (default) means no limit.
+
+        Returns
+        -------
+        list[dict[str, Any]]
+            One dict per PDF with keys: ``id``, ``path``, ``size``,
+            ``modified``, ``pdf_meta``.
+        """
+        self._ensure_connected()
+        assert self._config is not None
+
+        results: List[dict[str, Any]] = []
+
+        for pdf_path in sorted(self._config.folder_path.rglob("*.pdf")):
+            if limit != -1 and len(results) >= limit:
+                break
+
+            stat = pdf_path.stat()
+            pdf_meta: dict[str, Any] = {}
+            try:
+                reader = PdfReader(str(pdf_path))
+                if reader.metadata:
+                    pdf_meta = {
+                        k.lstrip("/"): v
+                        for k, v in reader.metadata.items()
+                        if v is not None
+                    }
+            except Exception as exc:
+                logger.warning(f"Could not read PDF metadata for '{pdf_path}': {exc}")
+
+            results.append({
+                "id":       str(pdf_path.relative_to(self._config.folder_path)),
+                "path":     pdf_path,
+                "size":     stat.st_size,
+                "modified": datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc),
+                "pdf_meta": pdf_meta,
+            })
+
+        return results
+
+    def get_list_artefacts(
+        self, last_synced: Optional[datetime]
+    ) -> list[tuple[str, datetime]]:
+        """
+        Return PDF files modified after ``last_synced``.
+
+        Parameters
+        ----------
+        last_synced : datetime | None
+            UTC timestamp of the last successful sync.
+            If ``None``, all discovered PDF files are returned.
+
+        Returns
+        -------
+        list[tuple[str, datetime]]
+            ``(relative_path, mtime_utc)`` pairs, sorted ascending by mtime.
+
+        Sync guarantees
+        ---------------
+        - Identifiers are stable across runs as long as files are not moved.
+        - Timestamps are timezone-aware UTC.
+        - Newly created and modified files are included; deletions are not reported.
+        """
+        self._ensure_connected()
+        assert self._config is not None
+
+        if last_synced is not None and last_synced.tzinfo is None:
+            last_synced = last_synced.replace(tzinfo=timezone.utc)
+
+        artefacts: list[tuple[str, datetime]] = []
+
+        for pdf_path in self._config.folder_path.rglob("*.pdf"):
+            modified = datetime.fromtimestamp(pdf_path.stat().st_mtime, tz=timezone.utc)
+            if last_synced is None or modified > last_synced:
+                artefacts.append((
+                    str(pdf_path.relative_to(self._config.folder_path)),
+                    modified,
+                ))
+
+        artefacts.sort(key=lambda t: t[1])
+        logger.info(
+            f"get_list_artefacts: {len(artefacts)} new/modified PDF(s) "
+            f"since {last_synced}."
+        )
+        return artefacts
+
+    def get_content(self, artefacts: list[tuple[str, datetime]]) -> list[Content]:
+        """
+        Parse and enrich PDFs, returning one ``Content`` per artefact.
+
+        Pipeline per file
+        -----------------
+        1. **Parse** – ``DocumentParserDocling.parse()`` converts the PDF to a
+           ``ParsedDocument`` containing the Docling IR, sections, tables,
+           figures, footnotes, and furniture.
+        2. **Metadata** – embedded PDF metadata is read via ``pypdf`` and merged
+           with structural metadata from the ``ParsedDocument`` (page count,
+           section titles, figure/table counts).
+        3. **Chunking** – ``SectionsConfig.chunking_strategy.chunk()`` converts
+           ``ParsedDocument.sections`` into ``Chunk`` objects.  The summary
+           extracted from Docling's abstract/summary section is forwarded so
+           strategies like :class:`SummaryAndSectionsStrategy` can use it.
+        4. **Embedding** – when ``SectionsConfig.embedder`` is set, its
+           ``embed()`` method populates each ``Chunk.vector`` in one batched
+           call.
+        5. **Assembly** – everything is packed into a ``Content`` object.
+
+        Errors in steps 1–4 are caught and logged; a ``Content`` is always
+        returned so a single bad file does not abort the batch.
+
+        Parameters
+        ----------
+        artefacts : list[tuple[str, datetime]]
+            As returned by :meth:`get_list_artefacts`.
+
+        Returns
+        -------
+        list[Content]
+            One ``Content`` per artefact in the same order.
+
+        Raises
+        ------
+        RuntimeError
+            If called before :meth:`connect`.
+        KeyError
+            If an artefact's path no longer exists on disk.
+        """
+        self._ensure_connected()
+        assert self._config is not None
+        assert self._parser is not None
+
+        contents: list[Content] = []
+
+        for relative_id, modified in artefacts:
+            pdf_path = self._config.folder_path / relative_id
+
+            if not pdf_path.exists():
+                raise KeyError(
+                    f"Artefact '{relative_id}' no longer exists at '{pdf_path}'."
+                )
+
+            stat = pdf_path.stat()
+            pdf_path_str = str(pdf_path.resolve())
+
+            # ── 1. Parse ─────────────────────────────────────────────────────
+            parsed: Optional[ParsedDocument] = None
+            num_pages: Optional[int] = None
+            try:
+                parsed = self._parser.parse(pdf_path_str)
+                num_pages = len(parsed.doc.pages) if parsed.doc.pages else None
+            except DocumentConversionError as exc:
+                logger.warning(f"Docling conversion failed for '{relative_id}': {exc}")
+            except Exception as exc:
+                logger.warning(f"Unexpected parse error for '{relative_id}': {exc}")
+
+            # ── 2. Metadata ───────────────────────────────────────────────────
+            pdf_meta = self._read_pdf_meta(pdf_path_str)
+            structural_meta = self._structural_meta(parsed)
+
+            # ── 3. Chunking ───────────────────────────────────────────────────
+            chunks: list[Chunk] = []
+            if self._config.sections.enabled and parsed is not None:
+                chunks = self._chunk(parsed=parsed, document_id=relative_id)
+
+            # ── 4. Embedding ──────────────────────────────────────────────────
+            if chunks and self._config.sections.embedder is not None:
+                chunks = self._embed(chunks)
+
+            # ── 5. Assemble ───────────────────────────────────────────────────
+            contents.append(Content(
+                date=modified,
+                id_=relative_id,
+                content={
+                    "file_path":       pdf_path_str,
+                    "file_name":       pdf_path.name,
+                    "file_size":       stat.st_size,
+                    "num_pages":       num_pages,
+                    "pdf_meta":        pdf_meta,
+                    **structural_meta,
+                    "chunks":          [dataclasses.asdict(c) for c in chunks],
+                },
+            ))
+            logger.debug(
+                f"Processed '{relative_id}': {len(chunks)} chunk(s)."
+            )
+
+        logger.info(f"get_content returning {len(contents)} Content object(s).")
+        return contents
+
+    def _read_pdf_meta(self, pdf_path_str: str) -> dict[str, Any]:
+        """
+        Read embedded PDF metadata via ``pypdf``.
+
+        Returns an empty dict on any read error (logged as a warning) so that
+        a corrupt or password-protected PDF does not abort the pipeline.
+        """
+        try:
+            reader = PdfReader(pdf_path_str)
+            if reader.metadata:
+                return {
+                    k.lstrip("/"): v
+                    for k, v in reader.metadata.items()
+                    if v is not None
+                }
+        except Exception as exc:
+            logger.warning(f"Could not read PDF metadata for '{pdf_path_str}': {exc}")
+        return {}
+
+    @staticmethod
+    def _structural_meta(parsed: Optional[ParsedDocument]) -> dict[str, Any]:
+        """
+        Derive lightweight structural metadata from a ``ParsedDocument``.
+
+        Returns counts and titles that are cheap to compute and useful for
+        filtering without loading the full chunk list.  Returns all-zero /
+        empty values when *parsed* is ``None`` (i.e. conversion failed).
+        """
+        if parsed is None:
+            return {
+                "num_sections": 0,
+                "num_tables":   0,
+                "num_figures":  0,
+                "section_titles": [],
+            }
+        return {
+            "num_sections":   len(parsed.sections),
+            "num_tables":     len(parsed.tables),
+            "num_figures":    len(parsed.figures),
+            "section_titles": [title for title, _, _ in parsed.sections if title],
+        }
+
+    def _chunk(
+        self,
+        *,
+        parsed: ParsedDocument,
+        document_id: str,
+    ) -> list[Chunk]:
+        """
+        Apply the configured ``AbstractChunkingStrategy`` to parsed sections.
+
+        The summary is derived from the first section whose title matches
+        common abstract/summary header names and forwarded to the strategy so
+        that :class:`SummaryAndSectionsStrategy` (and similar) can prepend it
+        as chunk 0.
+
+        Returns an empty list on any error (logged as a warning).
+        """
+        assert self._config is not None
+        try:
+            summary = self._find_summary(parsed)
+            chunks = self._config.sections.chunking_strategy.chunk(
+                parsed.sections,
+                document_id=document_id,
+                summary=summary,
+            )
+            logger.debug(f"Chunked '{document_id}': {len(chunks)} chunk(s).")
+            return chunks
+        except Exception as exc:
+            logger.warning(f"Chunking failed for '{document_id}': {exc}")
+            return []
+
+    def _embed(self, chunks: list[Chunk]) -> list[Chunk]:
+        """
+        Populate ``Chunk.vector`` for each chunk via the configured embedder.
+
+        Returns the original chunks unchanged (with a warning) if the embedder
+        raises, so downstream indexing can still store text-only records.
+        """
+        assert self._config is not None
+        assert self._config.sections.embedder is not None
+        try:
+            embedded = self._config.sections.embedder.embed(chunks)
+            logger.debug(f"Embedded {len(embedded)} chunk(s).")
+            return embedded
+        except Exception as exc:
+            logger.warning(f"Embedding failed; returning chunks without vectors: {exc}")
+            return chunks
+
+    @staticmethod
+    def _find_summary(parsed: ParsedDocument) -> Optional[str]:
+        """
+        Return the body text of the first abstract / summary section, or ``None``.
+
+        Matches section titles case-insensitively against a small set of common
+        header names used in academic and technical documents.
+        """
+        _SUMMARY_HEADERS = {"abstract", "summary", "executive summary", "samenvatting"}
+        for title, text, _ in parsed.sections:
+            if title.strip().lower() in _SUMMARY_HEADERS:
+                return text.strip() or None
+        return None

--- a/src/database_builder_libs/sources/pdf_source.py
+++ b/src/database_builder_libs/sources/pdf_source.py
@@ -1,19 +1,22 @@
 from __future__ import annotations
 
 import dataclasses
-import os
+import json
+import re
 from datetime import datetime, timezone
+from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional
 
-from enum import Enum
 from loguru import logger
 from pydantic import BaseModel, Field, PrivateAttr, field_validator
 from pypdf import PdfReader
 
-from database_builder_libs.models.abstract_source import AbstractSource, Content
+from docling_core.types.doc import SectionHeaderItem, TextItem
+
 from database_builder_libs.models.abstract_chunk_embedder import AbstractChunkEmbedder
-from database_builder_libs.models.abstract_chunk_strategy import AbstractChunkingStrategy, RawSection
+from database_builder_libs.models.abstract_chunk_strategy import AbstractChunkingStrategy
+from database_builder_libs.models.abstract_source import AbstractSource, Content
 from database_builder_libs.models.chunk import Chunk
 from database_builder_libs.utility.chunk.n_points_section import SectionChunkingStrategy
 from database_builder_libs.utility.extract.document_parser_docling import (
@@ -23,21 +26,89 @@ from database_builder_libs.utility.extract.document_parser_docling import (
 )
 
 
+# --------------------------------------------------------------------------- #
+# Extracted metadata                                                           #
+# --------------------------------------------------------------------------- #
+
+@dataclasses.dataclass(slots=True)
+class Institution:
+    """A publishing institution."""
+    name: str
+    parent: Optional[str] = None
+
+
+@dataclasses.dataclass(slots=True)
+class Acknowledgement:
+    """An entity acknowledged in the document."""
+    name: str
+    type: str      # "person" | "organization" | "group"
+    relation: str  # "funding" | "collaboration" | "contribution" | "review" | "support"
+
+
+@dataclasses.dataclass(slots=True)
+class DocumentMetadata:
+    """
+    Rich metadata extracted from a PDF document.
+
+    Produced by :class:`PDFSource` and serialised into
+    ``Content.content["metadata"]`` via ``dataclasses.asdict()``.
+
+    Fields
+    ------
+    title : str | None
+        Document title.
+    authors : list[str] | None
+        Personal author names.
+    publishing_institute : Institution | None
+        Publisher or issuing organisation.
+    summary : str | None
+        Abstract or executive summary text.
+    acknowledgements : list[Acknowledgement]
+        Entities acknowledged in the document.
+    source : dict[str, str]
+        Maps each populated field to the strategy that filled it
+        (e.g. ``{"title": "docling_heuristic", "authors": "llm"}``).
+    keywords : list[str] | None
+        Keywords or tags associated with the document.
+    literature_type : str | None
+        Document type (e.g. ``"report"``, ``"article"``).
+    strategic_overview : list[str] | None
+        Strategic themes extracted from tags.
+    target_groups : list[str] | None
+        Target audience groups extracted from tags.
+    best_practices : list[str] | None
+        Best practice topics extracted from tags.
+    """
+
+    title: Optional[str] = None
+    authors: Optional[List[str]] = None
+    publishing_institute: Optional[Institution] = None
+    summary: Optional[str] = None
+    acknowledgements: List[Acknowledgement] = dataclasses.field(default_factory=list)
+    source: Dict[str, str] = dataclasses.field(default_factory=dict)
+    keywords: Optional[List[str]] = None
+    literature_type: Optional[str] = None
+    strategic_overview: Optional[List[str]] = None
+    target_groups: Optional[List[str]] = None
+    best_practices: Optional[List[str]] = None
+
+
+# --------------------------------------------------------------------------- #
+# Strategy config                                                              #
+# --------------------------------------------------------------------------- #
+
 class ExtractionStrategy(str, Enum):
-    DOCLING = "docling"
-    LLM = "llm"
-    FILE_METADATA = "file_metadata"
-
-
-class StrategyConfig(BaseModel):
-    timeout: Optional[int] = None
-    confidence_threshold: Optional[float] = None
+    """Which engine to use when extracting a metadata field."""
+    FILE_METADATA = "file_metadata"  # embedded PDF metadata via pypdf
+    DOCLING       = "docling"        # structural heuristics from Docling IR
+    LLM           = "llm"            # LLM extraction from document header text
 
 
 class OrderedStrategyConfig(BaseModel):
+    """Ordered list of strategies to try for a single metadata field."""
+
     order: List[ExtractionStrategy] = Field(default_factory=list)
     stop_on_success: bool = True
-    configs: Dict[ExtractionStrategy, StrategyConfig] = Field(default_factory=dict)
 
     @field_validator("order")
     def no_duplicates(cls, v: list) -> list:
@@ -47,6 +118,8 @@ class OrderedStrategyConfig(BaseModel):
 
 
 class FieldExtractionConfig(BaseModel):
+    """Configuration for extracting a single metadata field."""
+
     enabled: bool = True
     strategies: OrderedStrategyConfig = Field(default_factory=OrderedStrategyConfig)
 
@@ -58,16 +131,11 @@ class SectionsConfig(BaseModel):
     Attributes
     ----------
     enabled : bool
-        When ``False`` no chunks are produced and ``Content.content["chunks"]``
-        will be an empty list.
+        When ``False`` no chunks are produced.
     chunking_strategy : AbstractChunkingStrategy
-        Strategy used to convert ``ParsedDocument.sections`` into ``Chunk``
-        objects.  Defaults to :class:`SectionChunkingStrategy` (one chunk per
-        section).
+        Defaults to :class:`SectionChunkingStrategy` (one chunk per section).
     embedder : AbstractChunkEmbedder | None
-        When provided, its ``embed()`` method is called on the produced chunks
-        to populate their ``vector`` fields before assembly.  When ``None``
-        chunks are returned with empty vectors.
+        When set, ``embed()`` is called on all chunks after chunking.
     """
 
     enabled: bool = True
@@ -79,166 +147,98 @@ class SectionsConfig(BaseModel):
     model_config = {"arbitrary_types_allowed": True}
 
 
+# --------------------------------------------------------------------------- #
+# PDFDocumentConfig                                                            #
+# --------------------------------------------------------------------------- #
+
 class PDFDocumentConfig(BaseModel):
     """
-    Configuration for the PDF source pipeline.
- 
-    Each ``FieldExtractionConfig`` controls which extraction engines are tried
-    for that metadata field, in order, stopping on first success when
-    ``stop_on_success`` is ``True``.
- 
-    Attributes
-    ----------
-    folder_path : Path
-        Root directory scanned recursively for ``*.pdf`` files.
-    title, authors, authors_institute, summary, abstract,
-    publishing_institute, acknowledgements : FieldExtractionConfig
-        Per-field extraction configuration with ordered strategy lists.
-    sections : SectionsConfig
-        Controls section extraction, chunking strategy, and optional embedding.
- 
+    Full configuration for the PDFSource pipeline.
+
+    Every metadata field has a ``FieldExtractionConfig`` with an ordered list
+    of :class:`ExtractionStrategy` values.  The pipeline tries each strategy
+    in order and stops on first success when ``stop_on_success=True``.
+
+    Available strategies
+    --------------------
+    ``FILE_METADATA``
+        Reads embedded PDF metadata via ``pypdf`` (fast, no ML).
+        Reliable for title and authors in well-tagged PDFs; often noisy for
+        documents originally produced from Word.
+    ``DOCLING``
+        Infers fields from the Docling structural IR: first section header /
+        first plausible line for title; abstract/summary section for summary.
+    ``LLM``
+        Sends the first ~60 lines of the document to the configured LLM and
+        parses a JSON response for authors and acknowledgements.
+        Requires ``llm_base_url`` and ``llm_api_key`` to be set.
+
+    Defaults
+    --------
+    - ``title``   : FILE_METADATA → DOCLING
+    - ``authors`` : FILE_METADATA → LLM
+    - ``summary`` : DOCLING
+    - ``publishing_institute`` : FILE_METADATA
+    - ``acknowledgements`` : LLM
+
     Usage
     -----
-    **Minimal — defaults only**
- 
-    The simplest valid config only requires ``folder_path``.  All metadata
-    fields use their built-in strategy defaults and sections are extracted
-    with one chunk per section, no embedding::
- 
-        config = PDFDocumentConfig(folder_path=Path("/data/papers"))
- 
-    **Connecting PDFSource**
- 
-    Pass the config as a plain dict to ``PDFSource.connect()``::
- 
+    Minimal — only ``folder_path`` is required::
+
         src = PDFSource()
+        src.connect({"folder_path": "/data/papers"})
+
+    With LLM enrichment for authors::
+
+        src.connect({
+            "folder_path":  "/data/papers",
+            "llm_base_url": "http://localhost:11434/v1",
+            "llm_api_key":  "ollama",
+            "llm_model":    "gemma2:9b",
+        })
+
+    Disable LLM entirely — FILE_METADATA + DOCLING only::
+
         src.connect({
             "folder_path": "/data/papers",
+            "authors": FieldExtractionConfig(
+                strategies=OrderedStrategyConfig(
+                    order=[ExtractionStrategy.FILE_METADATA, ExtractionStrategy.DOCLING]
+                )
+            ),
+            "acknowledgements": FieldExtractionConfig(enabled=False),
         })
- 
-    **Customising metadata extraction strategies**
- 
-    Each metadata field accepts an ``enabled`` flag and an ordered list of
-    ``ExtractionStrategy`` values.  The pipeline tries each strategy in order
-    and stops on the first that produces a result (``stop_on_success=True``).
- 
-    Available strategies:
- 
-    - ``ExtractionStrategy.FILE_METADATA`` — reads embedded PDF metadata via
-      ``pypdf`` (fast, no ML required).
-    - ``ExtractionStrategy.DOCLING`` — uses Docling's structural extraction
-      (section headers, abstract detection).
-    - ``ExtractionStrategy.LLM`` — sends the first page to an LLM for
-      extraction (requires ``OPENAI_API_KEY`` in the environment).
- 
-    Example — use only ``FILE_METADATA`` for title, disable
-    ``authors_institute`` entirely, and try ``DOCLING`` then ``LLM`` for
-    summary::
- 
-        config = PDFDocumentConfig(
-            folder_path=Path("/data/papers"),
-            title=FieldExtractionConfig(
-                strategies=OrderedStrategyConfig(
-                    order=[ExtractionStrategy.FILE_METADATA],
-                )
-            ),
-            authors_institute=FieldExtractionConfig(enabled=False),
-            summary=FieldExtractionConfig(
-                strategies=OrderedStrategyConfig(
-                    order=[ExtractionStrategy.DOCLING, ExtractionStrategy.LLM],
-                    stop_on_success=True,
-                )
-            ),
-        )
- 
-    **Customising chunking strategy**
- 
-    Supply any ``AbstractChunkingStrategy`` implementation via
-    ``SectionsConfig.chunking_strategy``.  The default is
-    ``SectionChunkingStrategy`` (one chunk per Docling section).
- 
-    Switch to fixed-size windows of 800 characters::
- 
-        from database_builder_libs.utility.chunk.n_points_fixed_size import (
-            FixedSizeChunkingStrategy,
-        )
- 
-        config = PDFDocumentConfig(
-            folder_path=Path("/data/papers"),
-            sections=SectionsConfig(
-                chunking_strategy=FixedSizeChunkingStrategy(chunk_size=800),
-            ),
-        )
- 
-    Use the summary-and-sections strategy (prepends an abstract chunk, then
-    splits the rest into 5 evenly-sized body chunks)::
- 
-        from database_builder_libs.utility.chunk.summary_and_sections import (
-            SummaryAndSectionsStrategy,
-        )
- 
-        config = PDFDocumentConfig(
-            folder_path=Path("/data/papers"),
-            sections=SectionsConfig(
-                chunking_strategy=SummaryAndSectionsStrategy(min_chars=30),
-            ),
-        )
- 
-    **Adding an embedder**
- 
-    Attach any ``AbstractChunkEmbedder`` to ``SectionsConfig.embedder``.
-    Chunks are embedded in a single batched call immediately after chunking.
- 
-    OpenAI-compatible endpoint (e.g. Ollama running locally)::
- 
-        from database_builder_libs.utility.embed_chunk.openai_compatible import (
-            OpenAICompatibleChunkEmbedder,
-        )
- 
-        config = PDFDocumentConfig(
-            folder_path=Path("/data/papers"),
-            sections=SectionsConfig(
-                chunking_strategy=SectionChunkingStrategy(),
+
+    With chunking and embedding::
+
+        from database_builder_libs.utility.chunk.summary_and_sections import SummaryAndSectionsStrategy
+        from database_builder_libs.utility.embed_chunk.openai_compatible import OpenAICompatibleChunkEmbedder
+
+        src.connect({
+            "folder_path": "/data/papers",
+            "sections": SectionsConfig(
+                chunking_strategy=SummaryAndSectionsStrategy(),
                 embedder=OpenAICompatibleChunkEmbedder(
                     base_url="http://localhost:11434/v1",
                     api_key="ollama",
                     model="nomic-embed-text",
                 ),
             ),
-        )
- 
-    Local HuggingFace transformer model::
- 
-        from database_builder_libs.utility.embed_chunk.transformer_based import (
-            TransformersChunkEmbedder,
-        )
- 
-        config = PDFDocumentConfig(
-            folder_path=Path("/data/papers"),
-            sections=SectionsConfig(
-                embedder=TransformersChunkEmbedder(
-                    model_name_or_path="sentence-transformers/all-MiniLM-L6-v2",
-                    batch_size=64,
-                ),
-            ),
-        )
- 
-    **Disabling section extraction**
- 
-    Set ``sections.enabled = False`` to skip chunking entirely.  The
-    ``Content.content["chunks"]`` list will be empty but all other metadata
-    fields are still extracted::
- 
-        config = PDFDocumentConfig(
-            folder_path=Path("/data/papers"),
-            sections=SectionsConfig(enabled=False),
-        )
+        })
     """
- 
+
     folder_path: Path
- 
-    title: FieldExtractionConfig = Field(default_factory=FieldExtractionConfig)
- 
+
+    # ── metadata field configs ──────────────────────────────────────────────
+
+    title: FieldExtractionConfig = Field(
+        default_factory=lambda: FieldExtractionConfig(
+            strategies=OrderedStrategyConfig(
+                order=[ExtractionStrategy.FILE_METADATA, ExtractionStrategy.DOCLING]
+            )
+        )
+    )
+
     authors: FieldExtractionConfig = Field(
         default_factory=lambda: FieldExtractionConfig(
             strategies=OrderedStrategyConfig(
@@ -246,62 +246,83 @@ class PDFDocumentConfig(BaseModel):
             )
         )
     )
- 
-    authors_institute: FieldExtractionConfig = Field(default_factory=FieldExtractionConfig)
- 
+
     summary: FieldExtractionConfig = Field(
         default_factory=lambda: FieldExtractionConfig(
             strategies=OrderedStrategyConfig(
-                order=[ExtractionStrategy.DOCLING, ExtractionStrategy.LLM]
+                order=[ExtractionStrategy.DOCLING]
             )
         )
     )
- 
-    abstract: FieldExtractionConfig = Field(
+
+    publishing_institute: FieldExtractionConfig = Field(
         default_factory=lambda: FieldExtractionConfig(
             strategies=OrderedStrategyConfig(
-                order=[ExtractionStrategy.DOCLING, ExtractionStrategy.LLM]
+                order=[ExtractionStrategy.FILE_METADATA]
             )
         )
     )
- 
-    publishing_institute: FieldExtractionConfig = Field(default_factory=FieldExtractionConfig)
-    acknowledgements: FieldExtractionConfig = Field(default_factory=FieldExtractionConfig)
+
+    acknowledgements: FieldExtractionConfig = Field(
+        default_factory=lambda: FieldExtractionConfig(
+            strategies=OrderedStrategyConfig(
+                order=[ExtractionStrategy.LLM]
+            )
+        )
+    )
+
+    # ── section / chunking / embedding ─────────────────────────────────────
+
     sections: SectionsConfig = Field(default_factory=SectionsConfig)
- 
- 
+
+    # ── LLM connection ──────────────────────────────────────────────────────
+
+    llm_base_url: Optional[str] = None
+    llm_api_key:  Optional[str] = None
+    llm_model:    str = "gpt-4.1-mini"
+
+
+# --------------------------------------------------------------------------- #
+# PDFSource                                                                    #
+# --------------------------------------------------------------------------- #
+
+_SUMMARY_HEADERS = frozenset({"abstract", "summary", "executive summary", "samenvatting"})
+_PDF_META_JUNK   = frozenset({"unknown", "untitled", "microsoft word", "writer", "author"})
+_INSTITUTION_HINTS = frozenset({
+    "university", "institute", "research", "centre", "center", "group",
+    "foundation", "association", "agency", "organisation", "organization",
+    "network", "ministry", "department",
+})
+
 
 class PDFSource(AbstractSource):
     """
-    PDF document source implementation of AbstractSource.
-
-    Provides incremental synchronisation of a folder of PDF files and exposes
-    each file as a canonical ``Content`` object containing extracted metadata,
-    structured sections, and optionally embedded ``Chunk`` objects.
+    Self-contained PDF source that parses, extracts metadata, chunks, and
+    embeds in a single configurable pipeline.
 
     Mapping
     -------
     PDF file path (relative)  →  Content.id_
     File mtime (UTC)          →  Content.date
-    Extracted payload         →  Content.content
 
     Content.content keys
     --------------------
-    ``file_path``   – absolute path on disk
-    ``file_name``   – basename
-    ``file_size``   – bytes
-    ``num_pages``   – page count from pypdf (``None`` on read error)
-    ``pdf_meta``    – raw embedded PDF metadata dict from pypdf
-    ``sections``    – list of ``(title, text, tables)`` dicts from Docling
-    ``chunks``      – list of serialised ``Chunk`` dicts, ready for indexing
+    ``file_path``, ``file_name``, ``file_size``, ``num_pages``
+        File-level stats.
+    ``pdf_meta``
+        Raw pypdf embedded metadata dict.
+    ``num_sections``, ``num_tables``, ``num_figures``, ``section_titles``
+        Structural counts from Docling.
+    ``metadata``
+        :class:`DocumentMetadata` serialised via ``dataclasses.asdict()``.
+    ``chunks``
+        List of :class:`~database_builder_libs.models.chunk.Chunk` dicts.
 
     Synchronisation semantics
     -------------------------
-    - ``get_list_artefacts()`` performs incremental sync using file-system mtime.
-    - Files with ``mtime > last_synced`` are returned; deletions are not reported.
-    - Returned timestamps are timezone-aware UTC.
-    - Identifiers (relative paths) are stable across runs as long as files are
-      not renamed or moved.
+    - ``get_list_artefacts()`` uses file-system mtime for incremental sync.
+    - Deletions are not reported.
+    - Identifiers are stable as long as files are not moved.
 
     Lifecycle
     ---------
@@ -310,16 +331,16 @@ class PDFSource(AbstractSource):
 
     _config: Optional[PDFDocumentConfig] = PrivateAttr(default=None)
     _parser: Optional[DocumentParserDocling] = PrivateAttr(default=None)
+    _llm_client: Any = PrivateAttr(default=None)
+
+    # ------------------------------------------------------------------ #
+    # Lifecycle                                                            #
+    # ------------------------------------------------------------------ #
 
     def _connect_impl(self, config: Mapping[str, Any]) -> None:
         """
-        Validate config and initialise the Docling parser.
-
-        Parameters
-        ----------
-        config : Mapping[str, Any]
-            Must contain at least ``folder_path`` pointing to an existing
-            directory.  All other keys map to ``PDFDocumentConfig`` fields.
+        Validate config, initialise the Docling parser, and build the LLM
+        client if ``llm_base_url`` and ``llm_api_key`` are provided.
 
         Raises
         ------
@@ -332,81 +353,49 @@ class PDFSource(AbstractSource):
                 f"folder_path '{self._config.folder_path}' does not exist or is not a directory."
             )
         self._parser = DocumentParserDocling()
+        self._llm_client = self._build_llm_client()
         logger.info(f"PDFSource connected to folder: {self._config.folder_path}")
+
+    # ------------------------------------------------------------------ #
+    # Public API                                                           #
+    # ------------------------------------------------------------------ #
 
     def get_all_documents_metadata(self, limit: int = -1) -> List[dict[str, Any]]:
         """
-        Retrieve file-level metadata for all PDFs in the configured folder.
+        Return lightweight file-level metadata for all PDFs in the folder.
 
-        Recursively scans ``folder_path`` for ``*.pdf`` files and reads their
-        embedded PDF metadata via ``pypdf``.  No Docling conversion is
-        performed; this method is intended for quick inventory purposes.
+        No Docling conversion is performed.  Intended for quick inventory.
 
-        Parameters
-        ----------
-        limit : int, optional
-            Maximum number of documents to return.  ``-1`` (default) means no limit.
-
-        Returns
-        -------
-        list[dict[str, Any]]
-            One dict per PDF with keys: ``id``, ``path``, ``size``,
-            ``modified``, ``pdf_meta``.
+        Returns one dict per PDF with keys:
+        ``id``, ``path``, ``size``, ``modified``, ``pdf_meta``.
         """
         self._ensure_connected()
         assert self._config is not None
 
         results: List[dict[str, Any]] = []
-
         for pdf_path in sorted(self._config.folder_path.rglob("*.pdf")):
             if limit != -1 and len(results) >= limit:
                 break
-
             stat = pdf_path.stat()
-            pdf_meta: dict[str, Any] = {}
-            try:
-                reader = PdfReader(str(pdf_path))
-                if reader.metadata:
-                    pdf_meta = {
-                        k.lstrip("/"): v
-                        for k, v in reader.metadata.items()
-                        if v is not None
-                    }
-            except Exception as exc:
-                logger.warning(f"Could not read PDF metadata for '{pdf_path}': {exc}")
-
             results.append({
                 "id":       str(pdf_path.relative_to(self._config.folder_path)),
                 "path":     pdf_path,
                 "size":     stat.st_size,
                 "modified": datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc),
-                "pdf_meta": pdf_meta,
+                "pdf_meta": self._read_pdf_meta(str(pdf_path)),
             })
-
         return results
 
     def get_list_artefacts(
         self, last_synced: Optional[datetime]
     ) -> list[tuple[str, datetime]]:
         """
-        Return PDF files modified after ``last_synced``.
+        Return PDFs modified after ``last_synced``, sorted ascending by mtime.
 
         Parameters
         ----------
         last_synced : datetime | None
-            UTC timestamp of the last successful sync.
-            If ``None``, all discovered PDF files are returned.
-
-        Returns
-        -------
-        list[tuple[str, datetime]]
-            ``(relative_path, mtime_utc)`` pairs, sorted ascending by mtime.
-
-        Sync guarantees
-        ---------------
-        - Identifiers are stable across runs as long as files are not moved.
-        - Timestamps are timezone-aware UTC.
-        - Newly created and modified files are included; deletions are not reported.
+            UTC timestamp of last sync.  ``None`` returns all files.
         """
         self._ensure_connected()
         assert self._config is not None
@@ -415,7 +404,6 @@ class PDFSource(AbstractSource):
             last_synced = last_synced.replace(tzinfo=timezone.utc)
 
         artefacts: list[tuple[str, datetime]] = []
-
         for pdf_path in self._config.folder_path.rglob("*.pdf"):
             modified = datetime.fromtimestamp(pdf_path.stat().st_mtime, tz=timezone.utc)
             if last_synced is None or modified > last_synced:
@@ -425,52 +413,33 @@ class PDFSource(AbstractSource):
                 ))
 
         artefacts.sort(key=lambda t: t[1])
-        logger.info(
-            f"get_list_artefacts: {len(artefacts)} new/modified PDF(s) "
-            f"since {last_synced}."
-        )
+        logger.info(f"get_list_artefacts: {len(artefacts)} PDF(s) since {last_synced}.")
         return artefacts
 
     def get_content(self, artefacts: list[tuple[str, datetime]]) -> list[Content]:
         """
-        Parse and enrich PDFs, returning one ``Content`` per artefact.
+        Run the full pipeline for each artefact and return one Content per file.
 
-        Pipeline per file
-        -----------------
-        1. **Parse** – ``DocumentParserDocling.parse()`` converts the PDF to a
-           ``ParsedDocument`` containing the Docling IR, sections, tables,
-           figures, footnotes, and furniture.
-        2. **Metadata** – embedded PDF metadata is read via ``pypdf`` and merged
-           with structural metadata from the ``ParsedDocument`` (page count,
-           section titles, figure/table counts).
-        3. **Chunking** – ``SectionsConfig.chunking_strategy.chunk()`` converts
-           ``ParsedDocument.sections`` into ``Chunk`` objects.  The summary
-           extracted from Docling's abstract/summary section is forwarded so
-           strategies like :class:`SummaryAndSectionsStrategy` can use it.
-        4. **Embedding** – when ``SectionsConfig.embedder`` is set, its
-           ``embed()`` method populates each ``Chunk.vector`` in one batched
-           call.
-        5. **Assembly** – everything is packed into a ``Content`` object.
+        Pipeline
+        --------
+        1. **Parse** – Docling converts the PDF to a ``ParsedDocument``.
+        2. **Metadata** – per-field strategy cascade populates
+           :class:`DocumentMetadata`.
+        3. **Chunking** – configured ``AbstractChunkingStrategy`` produces
+           ``Chunk`` objects from the parsed sections.
+        4. **Embedding** – configured ``AbstractChunkEmbedder`` (if any)
+           populates ``Chunk.vector``.
+        5. **Assembly** – everything is packed into ``Content``.
 
-        Errors in steps 1–4 are caught and logged; a ``Content`` is always
-        returned so a single bad file does not abort the batch.
-
-        Parameters
-        ----------
-        artefacts : list[tuple[str, datetime]]
-            As returned by :meth:`get_list_artefacts`.
-
-        Returns
-        -------
-        list[Content]
-            One ``Content`` per artefact in the same order.
+        Errors in any step are caught and logged; a ``Content`` is always
+        returned so one bad file does not abort the batch.
 
         Raises
         ------
         RuntimeError
-            If called before :meth:`connect`.
+            If called before ``connect()``.
         KeyError
-            If an artefact's path no longer exists on disk.
+            If an artefact no longer exists on disk.
         """
         self._ensure_connected()
         assert self._config is not None
@@ -480,121 +449,431 @@ class PDFSource(AbstractSource):
 
         for relative_id, modified in artefacts:
             pdf_path = self._config.folder_path / relative_id
-
             if not pdf_path.exists():
-                raise KeyError(
-                    f"Artefact '{relative_id}' no longer exists at '{pdf_path}'."
-                )
+                raise KeyError(f"Artefact '{relative_id}' no longer exists.")
 
-            stat = pdf_path.stat()
+            stat        = pdf_path.stat()
             pdf_path_str = str(pdf_path.resolve())
 
-            # ── 1. Parse ─────────────────────────────────────────────────────
+            # 1. Parse
             parsed: Optional[ParsedDocument] = None
             num_pages: Optional[int] = None
             try:
-                parsed = self._parser.parse(pdf_path_str)
+                parsed    = self._parser.parse(pdf_path_str)
                 num_pages = len(parsed.doc.pages) if parsed.doc.pages else None
             except DocumentConversionError as exc:
                 logger.warning(f"Docling conversion failed for '{relative_id}': {exc}")
             except Exception as exc:
                 logger.warning(f"Unexpected parse error for '{relative_id}': {exc}")
 
-            # ── 2. Metadata ───────────────────────────────────────────────────
-            pdf_meta = self._read_pdf_meta(pdf_path_str)
-            structural_meta = self._structural_meta(parsed)
+            # 2. Metadata
+            metadata = self._extract_metadata(pdf_path_str=pdf_path_str, parsed=parsed)
 
-            # ── 3. Chunking ───────────────────────────────────────────────────
+            # 3. Chunking
             chunks: list[Chunk] = []
             if self._config.sections.enabled and parsed is not None:
                 chunks = self._chunk(parsed=parsed, document_id=relative_id)
 
-            # ── 4. Embedding ──────────────────────────────────────────────────
+            # 4. Embedding
             if chunks and self._config.sections.embedder is not None:
                 chunks = self._embed(chunks)
 
-            # ── 5. Assemble ───────────────────────────────────────────────────
+            # 5. Assemble
             contents.append(Content(
                 date=modified,
                 id_=relative_id,
                 content={
-                    "file_path":       pdf_path_str,
-                    "file_name":       pdf_path.name,
-                    "file_size":       stat.st_size,
-                    "num_pages":       num_pages,
-                    "pdf_meta":        pdf_meta,
-                    **structural_meta,
-                    "chunks":          [dataclasses.asdict(c) for c in chunks],
+                    "file_path":      pdf_path_str,
+                    "file_name":      pdf_path.name,
+                    "file_size":      stat.st_size,
+                    "num_pages":      num_pages,
+                    "pdf_meta":       self._read_pdf_meta(pdf_path_str),
+                    "metadata":       dataclasses.asdict(metadata),
+                    **self._structural_meta(parsed),
+                    "chunks":         [dataclasses.asdict(c) for c in chunks],
                 },
             ))
-            logger.debug(
-                f"Processed '{relative_id}': {len(chunks)} chunk(s)."
-            )
+            logger.debug(f"Processed '{relative_id}': {len(chunks)} chunk(s).")
 
         logger.info(f"get_content returning {len(contents)} Content object(s).")
         return contents
 
-    def _read_pdf_meta(self, pdf_path_str: str) -> dict[str, Any]:
-        """
-        Read embedded PDF metadata via ``pypdf``.
+    # ------------------------------------------------------------------ #
+    # Metadata extraction                                                  #
+    # ------------------------------------------------------------------ #
 
-        Returns an empty dict on any read error (logged as a warning) so that
-        a corrupt or password-protected PDF does not abort the pipeline.
+    def _extract_metadata(
+        self,
+        *,
+        pdf_path_str: str,
+        parsed: Optional[ParsedDocument],
+    ) -> DocumentMetadata:
         """
+        Populate :class:`DocumentMetadata` by running each field's configured
+        strategy order, stopping on first success per field.
+
+        Each field consults its ``FieldExtractionConfig.strategies.order`` list
+        and calls the matching strategy method:
+
+        - ``FILE_METADATA`` → pypdf embedded metadata
+        - ``DOCLING``       → structural heuristics on the Docling IR
+        - ``LLM``           → JSON extraction via the configured LLM
+
+        Returns an empty :class:`DocumentMetadata` if *parsed* is ``None``
+        (conversion failed) or if all strategies fail.
+        """
+        assert self._config is not None
+        meta = DocumentMetadata()
+
+        if parsed is None:
+            return meta
+
+        try:
+            # Cache expensive operations computed at most once per document.
+            _lines:     Optional[List[str]]  = None
+            _pdf_info:  Optional[Any]        = None
+            _llm_result: Optional[dict[str, Any]] = None
+
+            def lines() -> List[str]:
+                nonlocal _lines
+                if _lines is None:
+                    _lines = self._first_lines(parsed.doc, limit=120)
+                return _lines
+
+            def pdf_info() -> Any:
+                nonlocal _pdf_info
+                if _pdf_info is None:
+                    try:
+                        _pdf_info = PdfReader(pdf_path_str).metadata or {}
+                    except Exception:
+                        _pdf_info = {}
+                return _pdf_info
+
+            def llm_result() -> dict[str, Any]:
+                nonlocal _llm_result
+                if _llm_result is None:
+                    _llm_result = self._call_llm(lines()) if self._llm_client else {}
+                return _llm_result
+
+            # ── title ─────────────────────────────────────────────────────
+            if self._config.title.enabled:
+                for strategy in self._config.title.strategies.order:
+                    if strategy == ExtractionStrategy.FILE_METADATA:
+                        raw = self._clean_meta_string(
+                            getattr(pdf_info(), "title", None)
+                            or pdf_info().get("/Title")
+                        )
+                        if raw:
+                            meta.title = raw
+                            meta.source["title"] = "pdf_metadata"
+                    elif strategy == ExtractionStrategy.DOCLING:
+                        val = self._first_section_header(parsed.doc) \
+                              or self._first_reasonable_line(lines())
+                        if val:
+                            meta.title = val
+                            meta.source["title"] = "docling_heuristic"
+                    elif strategy == ExtractionStrategy.LLM and self._llm_client:
+                        val = llm_result().get("title")
+                        if val:
+                            meta.title = val
+                            meta.source["title"] = "llm"
+                    if meta.title and self._config.title.strategies.stop_on_success:
+                        break
+
+            # ── authors ───────────────────────────────────────────────────
+            if self._config.authors.enabled:
+                for strategy in self._config.authors.strategies.order:
+                    if strategy == ExtractionStrategy.FILE_METADATA:
+                        raw = self._clean_meta_string(
+                            getattr(pdf_info(), "author", None)
+                            or pdf_info().get("/Author")
+                        )
+                        if raw:
+                            meta.authors = self._split_authors(raw)
+                            meta.source["authors"] = "pdf_metadata"
+                    elif strategy == ExtractionStrategy.DOCLING:
+                        for line in lines()[:10]:
+                            parsed_authors = self._parse_author_line(line)
+                            if len(parsed_authors) >= 2:
+                                meta.authors = parsed_authors
+                                meta.source["authors"] = "docling_heuristic"
+                                break
+                    elif strategy == ExtractionStrategy.LLM and self._llm_client:
+                        authors = llm_result().get("authors")
+                        if authors:
+                            meta.authors = authors
+                            meta.source["authors"] = "llm"
+                    if meta.authors and self._config.authors.strategies.stop_on_success:
+                        break
+
+            # ── summary ───────────────────────────────────────────────────
+            if self._config.summary.enabled:
+                for strategy in self._config.summary.strategies.order:
+                    if strategy == ExtractionStrategy.DOCLING:
+                        val = self._find_summary(parsed.doc)
+                        if val:
+                            meta.summary = val
+                            meta.source["summary"] = "docling_heuristic"
+                    elif strategy == ExtractionStrategy.LLM and self._llm_client:
+                        val = llm_result().get("summary")
+                        if val:
+                            meta.summary = val
+                            meta.source["summary"] = "llm"
+                    if meta.summary and self._config.summary.strategies.stop_on_success:
+                        break
+
+            # ── publishing_institute ──────────────────────────────────────
+            if self._config.publishing_institute.enabled:
+                for strategy in self._config.publishing_institute.strategies.order:
+                    if strategy == ExtractionStrategy.FILE_METADATA:
+                        raw = self._clean_meta_string(
+                            pdf_info().get("Producer") or pdf_info().get("/Producer")
+                            or pdf_info().get("Creator") or pdf_info().get("/Creator")
+                        )
+                        if raw and not any(j in raw.lower() for j in _PDF_META_JUNK):
+                            meta.publishing_institute = Institution(name=raw)
+                            meta.source["publishing_institute"] = "pdf_metadata"
+                    elif strategy == ExtractionStrategy.LLM and self._llm_client:
+                        val = llm_result().get("publishing_institute")
+                        if val:
+                            meta.publishing_institute = Institution(name=val)
+                            meta.source["publishing_institute"] = "llm"
+                    if meta.publishing_institute and \
+                            self._config.publishing_institute.strategies.stop_on_success:
+                        break
+
+            # ── acknowledgements ──────────────────────────────────────────
+            if self._config.acknowledgements.enabled:
+                for strategy in self._config.acknowledgements.strategies.order:
+                    if strategy == ExtractionStrategy.LLM and self._llm_client:
+                        raw_acks = llm_result().get("acknowledgements", [])
+                        acks = [
+                            Acknowledgement(
+                                name=a.get("name", ""),
+                                type=a.get("type", ""),
+                                relation=a.get("relation", ""),
+                            )
+                            for a in raw_acks
+                            if a.get("name")
+                        ]
+                        if acks:
+                            meta.acknowledgements = acks
+                            meta.source["acknowledgements"] = "llm"
+                    if meta.acknowledgements and \
+                            self._config.acknowledgements.strategies.stop_on_success:
+                        break
+
+        except Exception as exc:
+            logger.warning(f"Metadata extraction failed for '{pdf_path_str}': {exc}")
+
+        return meta
+
+    # ------------------------------------------------------------------ #
+    # LLM                                                                  #
+    # ------------------------------------------------------------------ #
+
+    def _build_llm_client(self) -> Optional[Any]:
+        """
+        Instantiate an OpenAI-compatible client from the config, or ``None``.
+
+        Returns ``None`` (with a warning) if ``llm_base_url`` / ``llm_api_key``
+        are unset or if the ``openai`` package is not installed.
+        """
+        assert self._config is not None
+        if not self._config.llm_base_url or not self._config.llm_api_key:
+            return None
+        try:
+            from openai import OpenAI
+            return OpenAI(
+                base_url=self._config.llm_base_url,
+                api_key=self._config.llm_api_key,
+            )
+        except ImportError:
+            logger.warning("openai package not installed; LLM extraction skipped.")
+            return None
+
+    def _call_llm(self, lines: List[str]) -> dict[str, Any]:
+        """
+        Send the first 60 lines to the LLM and parse the JSON response.
+
+        Returns a dict with keys ``authors``, ``acknowledgements``, and
+        optionally ``summary`` and ``publishing_institute``.  Returns an empty
+        dict on any failure.
+        """
+        assert self._config is not None
+        text = "\n".join(lines[:60])
+        prompt = f"""Extract metadata from the document header. Return only JSON.
+
+{{
+  "title": "Full document title or null",
+  "authors": ["First Last"],
+  "publishing_institute": "Name of publisher or null",
+  "acknowledgements": [
+    {{
+      "name": "Entity name",
+      "type": "person | organization | group",
+      "relation": "funding | collaboration | contribution | review | support"
+    }}
+  ]
+}}
+
+Rules:
+- title is the actual paper/report title, not a repository name, journal name, or tool artefact.
+- authors must be personal names only; ignore job titles and copyright text.
+- publishing_institute is the organisation that published or issued the document.
+- Extract acknowledgement entities mentioned in the header or acknowledgements section.
+
+Text:
+{text}
+"""
+        try:
+            res = self._llm_client.chat.completions.create(
+                model=self._config.llm_model,
+                temperature=0,
+                messages=[{"role": "user", "content": prompt}],
+            )
+            content = res.choices[0].message.content.strip()
+            match = re.search(r"\{.*\}", content, re.S)
+            if not match:
+                return {}
+            return json.loads(match.group(0))
+        except Exception as exc:
+            logger.warning(f"LLM call failed: {exc}")
+            return {}
+
+    # ------------------------------------------------------------------ #
+    # Docling structural helpers                                           #
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _first_lines(doc: Any, limit: int) -> List[str]:
+        out: List[str] = []
+        for node, _ in doc.iterate_items():
+            if isinstance(node, (SectionHeaderItem, TextItem)):
+                for ln in (node.text or "").strip().splitlines():
+                    ln = ln.strip()
+                    if ln:
+                        out.append(ln)
+                        if len(out) >= limit:
+                            return out
+        return out
+
+    # Known repository/watermark strings that are not real titles.
+    _TITLE_NOISE = frozenset({
+        "university of huddersfield repository",
+        "original citation",
+        "repository",
+        "preprint",
+        "author's accepted manuscript",
+        "accepted manuscript",
+        "post-print",
+    })
+
+    @classmethod
+    def _looks_like_title(cls, t: str) -> bool:
+        """Return True if *t* looks like a genuine document title."""
+        if len(t) < 8 or "@" in t or len(t.split()) < 2:
+            return False
+        # Skip strings that are entirely uppercase — usually section labels,
+        # not titles (the actual title in all-caps will be caught by LLM).
+        if t == t.upper() and len(t) > 30:
+            return False
+        if t.strip().lower() in cls._TITLE_NOISE:
+            return False
+        return True
+
+    @classmethod
+    def _first_section_header(cls, doc: Any) -> Optional[str]:
+        for node, _ in doc.iterate_items():
+            if isinstance(node, SectionHeaderItem):
+                t = (node.text or "").strip()
+                if cls._looks_like_title(t):
+                    return t
+        return None
+
+    @classmethod
+    def _first_reasonable_line(cls, lines: List[str]) -> Optional[str]:
+        for ln in lines[:30]:
+            if cls._looks_like_title(ln):
+                return ln
+        return None
+
+    @staticmethod
+    def _find_summary(doc: Any) -> Optional[str]:
+        collecting = False
+        collected: List[str] = []
+        for node, _ in doc.iterate_items():
+            if isinstance(node, SectionHeaderItem):
+                h = (node.text or "").strip().lower()
+                if any(k in h for k in _SUMMARY_HEADERS):
+                    collecting = True
+                    continue
+                if collecting:
+                    break
+            if collecting and isinstance(node, TextItem):
+                t = (node.text or "").strip()
+                if t:
+                    collected.append(t)
+        return "\n".join(collected[:4]) or None
+
+    # ------------------------------------------------------------------ #
+    # pypdf / author helpers                                               #
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _read_pdf_meta(pdf_path_str: str) -> dict[str, Any]:
         try:
             reader = PdfReader(pdf_path_str)
             if reader.metadata:
-                return {
-                    k.lstrip("/"): v
-                    for k, v in reader.metadata.items()
-                    if v is not None
-                }
+                return {k.lstrip("/"): v for k, v in reader.metadata.items() if v is not None}
         except Exception as exc:
             logger.warning(f"Could not read PDF metadata for '{pdf_path_str}': {exc}")
         return {}
 
     @staticmethod
-    def _structural_meta(parsed: Optional[ParsedDocument]) -> dict[str, Any]:
-        """
-        Derive lightweight structural metadata from a ``ParsedDocument``.
+    def _clean_meta_string(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        s = str(value).strip()
+        if not s or s.lower() in _PDF_META_JUNK:
+            return None
+        # reject strings that look like tool-generated titles
+        if s.lower().startswith("microsoft word"):
+            return None
+        return s
 
-        Returns counts and titles that are cheap to compute and useful for
-        filtering without loading the full chunk list.  Returns all-zero /
-        empty values when *parsed* is ``None`` (i.e. conversion failed).
-        """
-        if parsed is None:
-            return {
-                "num_sections": 0,
-                "num_tables":   0,
-                "num_figures":  0,
-                "section_titles": [],
-            }
-        return {
-            "num_sections":   len(parsed.sections),
-            "num_tables":     len(parsed.tables),
-            "num_figures":    len(parsed.figures),
-            "section_titles": [title for title, _, _ in parsed.sections if title],
-        }
+    @staticmethod
+    def _split_authors(s: str) -> List[str]:
+        if ";" in s:
+            parts = [p.strip() for p in s.split(";")]
+        elif re.search(r"\band\b", s, flags=re.I):
+            parts = [p.strip() for p in re.split(r"\band\b", s, flags=re.I)]
+        else:
+            parts = [s.strip()]
+        return [p for p in parts if p]
 
-    def _chunk(
-        self,
-        *,
-        parsed: ParsedDocument,
-        document_id: str,
-    ) -> list[Chunk]:
-        """
-        Apply the configured ``AbstractChunkingStrategy`` to parsed sections.
+    @staticmethod
+    def _parse_author_line(text: str) -> List[str]:
+        """Parse abbreviated author lines like ``Smith J., Doe A.``"""
+        text = text.replace(" and ", ",")
+        parts = [p.strip() for p in text.split(",") if p.strip()]
+        pattern = re.compile(r"^([A-Z][a-zA-Z\-']+)\s+([A-Z])\.?$")
+        authors = []
+        for part in parts:
+            m = pattern.match(part)
+            if m:
+                last, initial = m.groups()
+                authors.append(f"{initial} {last}")
+        return authors
 
-        The summary is derived from the first section whose title matches
-        common abstract/summary header names and forwarded to the strategy so
-        that :class:`SummaryAndSectionsStrategy` (and similar) can prepend it
-        as chunk 0.
+    # ------------------------------------------------------------------ #
+    # Chunking / embedding                                                 #
+    # ------------------------------------------------------------------ #
 
-        Returns an empty list on any error (logged as a warning).
-        """
+    def _chunk(self, *, parsed: ParsedDocument, document_id: str) -> list[Chunk]:
         assert self._config is not None
         try:
-            summary = self._find_summary(parsed)
+            summary = self._find_summary(parsed.doc)
             chunks = self._config.sections.chunking_strategy.chunk(
                 parsed.sections,
                 document_id=document_id,
@@ -607,12 +886,6 @@ class PDFSource(AbstractSource):
             return []
 
     def _embed(self, chunks: list[Chunk]) -> list[Chunk]:
-        """
-        Populate ``Chunk.vector`` for each chunk via the configured embedder.
-
-        Returns the original chunks unchanged (with a warning) if the embedder
-        raises, so downstream indexing can still store text-only records.
-        """
         assert self._config is not None
         assert self._config.sections.embedder is not None
         try:
@@ -623,16 +896,17 @@ class PDFSource(AbstractSource):
             logger.warning(f"Embedding failed; returning chunks without vectors: {exc}")
             return chunks
 
-    @staticmethod
-    def _find_summary(parsed: ParsedDocument) -> Optional[str]:
-        """
-        Return the body text of the first abstract / summary section, or ``None``.
+    # ------------------------------------------------------------------ #
+    # Structural meta                                                      #
+    # ------------------------------------------------------------------ #
 
-        Matches section titles case-insensitively against a small set of common
-        header names used in academic and technical documents.
-        """
-        _SUMMARY_HEADERS = {"abstract", "summary", "executive summary", "samenvatting"}
-        for title, text, _ in parsed.sections:
-            if title.strip().lower() in _SUMMARY_HEADERS:
-                return text.strip() or None
-        return None
+    @staticmethod
+    def _structural_meta(parsed: Optional[ParsedDocument]) -> dict[str, Any]:
+        if parsed is None:
+            return {"num_sections": 0, "num_tables": 0, "num_figures": 0, "section_titles": []}
+        return {
+            "num_sections":   len(parsed.sections),
+            "num_tables":     len(parsed.tables),
+            "num_figures":    len(parsed.figures),
+            "section_titles": [t for t, _, _ in parsed.sections if t],
+        }

--- a/src/database_builder_libs/sources/pdf_source.py
+++ b/src/database_builder_libs/sources/pdf_source.py
@@ -152,12 +152,6 @@ class PDFDocumentConfig(BaseModel):
 
 _SUMMARY_HEADERS   = frozenset({"abstract", "summary", "executive summary", "samenvatting"})
 _PDF_META_JUNK     = frozenset({"unknown", "untitled", "microsoft word", "writer", "author"})
-_INSTITUTION_HINTS = frozenset({
-    "university", "institute", "research", "centre", "center", "group",
-    "foundation", "association", "agency", "organisation", "organization",
-    "network", "ministry", "department",
-})
-
 
 class PDFSource(AbstractSource):
     """
@@ -222,13 +216,13 @@ class PDFSource(AbstractSource):
         if last_synced is not None and last_synced.tzinfo is None:
             last_synced = last_synced.replace(tzinfo=timezone.utc)
         artefacts = [
-            (str(p.relative_to(self._config.folder_path)),
-             datetime.fromtimestamp(p.stat().st_mtime, tz=timezone.utc))
-            for p in self._config.folder_path.rglob("*.pdf")
+            (str(pdf_path.relative_to(self._config.folder_path)),
+             datetime.fromtimestamp(pdf_path.stat().st_mtime, tz=timezone.utc))
+            for pdf_path in self._config.folder_path.rglob("*.pdf")
             if last_synced is None
-            or datetime.fromtimestamp(p.stat().st_mtime, tz=timezone.utc) > last_synced
+            or datetime.fromtimestamp(pdf_path.stat().st_mtime, tz=timezone.utc) > last_synced
         ]
-        artefacts.sort(key=lambda t: t[1])
+        artefacts.sort(key=lambda artefact: artefact[1])
         logger.info(f"get_list_artefacts: {len(artefacts)} PDF(s) since {last_synced}.")
         return artefacts
 
@@ -237,16 +231,16 @@ class PDFSource(AbstractSource):
         self._ensure_connected()
         assert self._config is not None
         assert self._parser is not None
-
+ 
         contents: list[Content] = []
         for relative_id, modified in artefacts:
             pdf_path = self._config.folder_path / relative_id
             if not pdf_path.exists():
                 raise KeyError(f"Artefact '{relative_id}' no longer exists.")
-
+ 
             stat         = pdf_path.stat()
             pdf_path_str = str(pdf_path.resolve())
-
+ 
             parsed: Optional[ParsedDocument] = None
             num_pages: Optional[int] = None
             try:
@@ -256,14 +250,14 @@ class PDFSource(AbstractSource):
                 logger.warning(f"Docling conversion failed for '{relative_id}': {exc}")
             except Exception as exc:
                 logger.warning(f"Unexpected parse error for '{relative_id}': {exc}")
-
+ 
             metadata = self._extract_metadata(pdf_path_str=pdf_path_str, parsed=parsed)
             chunks   = self._chunk(parsed=parsed, document_id=relative_id) if (
                 self._config.sections.enabled and parsed is not None
             ) else []
             if chunks and self._config.sections.embedder is not None:
                 chunks = self._embed(chunks)
-
+ 
             contents.append(Content(
                 date=modified,
                 id_=relative_id,
@@ -275,11 +269,11 @@ class PDFSource(AbstractSource):
                     "pdf_meta":   self._read_pdf_meta(pdf_path_str),
                     "metadata":   dataclasses.asdict(metadata),
                     **self._structural_meta(parsed),
-                    "chunks":     [dataclasses.asdict(c) for c in chunks],
+                    "chunks":     [dataclasses.asdict(chunk) for chunk in chunks],
                 },
             ))
             logger.debug(f"Processed '{relative_id}': {len(chunks)} chunk(s).")
-
+ 
         logger.info(f"get_content returning {len(contents)} Content object(s).")
         return contents
 
@@ -291,133 +285,130 @@ class PDFSource(AbstractSource):
         order, stopping on first success when stop_on_success=True.
         """
         assert self._config is not None
-        meta = DocumentMetadata()
+        metadata = DocumentMetadata()
         if parsed is None:
-            return meta
-
+            return metadata
+ 
         try:
             # ── lazy, cached accessors ────────────────────────────────────
             _cache: dict[str, Any] = {}
-
+ 
             def lines() -> List[str]:
                 if "lines" not in _cache:
                     _cache["lines"] = self._first_lines(parsed.doc, limit=120)
                 return _cache["lines"]
-
+ 
             def pdf_info() -> dict[str, Any]:
                 if "pdf_info" not in _cache:
                     try:
-                        raw = PdfReader(pdf_path_str).metadata or {}
-                        # raw may be a pypdf DocumentInformation object rather than
-                        # a plain dict — iterate items() but only keep entries whose
-                        # keys are real strings so MagicMock / PrivateAttr objects
-                        # from mismatched pydantic versions are silently dropped.
+                        raw_pdf_metadata = PdfReader(pdf_path_str).metadata or {}
                         info: dict[str, Any] = {}
-                        for k, v in raw.items():
-                            if isinstance(k, str):
-                                info[k.lstrip("/")] = v
-                        # Also check well-known attributes directly in case the
-                        # object exposes them as properties (pypdf DocumentInformation).
-                        for attr, key in (("title", "Title"), ("author", "Author"),
-                                          ("producer", "Producer"), ("creator", "Creator")):
-                            if key not in info:
-                                val = getattr(raw, attr, None)
-                                if isinstance(val, str):
-                                    info[key] = val
+                        for key, value in raw_pdf_metadata.items():
+                            if isinstance(key, str):
+                                info[key.lstrip("/")] = value
+                        for attr_name, dict_key in (
+                            ("title", "Title"), ("author", "Author"),
+                            ("producer", "Producer"), ("creator", "Creator"),
+                        ):
+                            if dict_key not in info:
+                                attr_value = getattr(raw_pdf_metadata, attr_name, None)
+                                if isinstance(attr_value, str):
+                                    info[dict_key] = attr_value
                         _cache["pdf_info"] = info
                     except Exception:
                         _cache["pdf_info"] = {}
                 return _cache["pdf_info"]
-
+ 
             def llm() -> dict[str, Any]:
                 if "llm" not in _cache:
                     _cache["llm"] = self._call_llm(lines()) if self._llm_client else {}
                 return _cache["llm"]
 
-            # ── per-field extractors: return (value, source_label) or None ─
-            S = ExtractionStrategy
-
-            def _title(s: S) -> Optional[Tuple[Any, str]]:
-                if s == S.FILE_METADATA:
-                    v = self._clean_meta_string(pdf_info().get("Title"))
-                    return (v, "pdf_metadata") if v else None
-                if s == S.DOCLING:
-                    v = self._first_section_header(parsed.doc) or self._first_reasonable_line(lines())
-                    return (v, "docling_heuristic") if v else None
-                if s == S.LLM and self._llm_client:
-                    v = llm().get("title")
-                    return (v, "llm") if v else None
-
-            def _authors(s: S) -> Optional[Tuple[Any, str]]:
-                if s == S.FILE_METADATA:
-                    raw = self._clean_meta_string(pdf_info().get("Author"))
-                    return (self._split_authors(raw), "pdf_metadata") if raw else None
-                if s == S.DOCLING:
+            def _extract_title(strategy: ExtractionStrategy) -> Optional[Tuple[Any, str]]:
+                if strategy == ExtractionStrategy.FILE_METADATA:
+                    title = self._clean_meta_string(pdf_info().get("Title"))
+                    return (title, "pdf_metadata") if title else None
+                if strategy == ExtractionStrategy.DOCLING:
+                    title = (
+                        self._first_section_header(parsed.doc)
+                        or self._first_reasonable_line(lines())
+                    )
+                    return (title, "docling_heuristic") if title else None
+                if strategy == ExtractionStrategy.LLM and self._llm_client:
+                    title = llm().get("title")
+                    return (title, "llm") if title else None
+ 
+            def _extract_authors(strategy: ExtractionStrategy) -> Optional[Tuple[Any, str]]:
+                if strategy == ExtractionStrategy.FILE_METADATA:
+                    raw_author = self._clean_meta_string(pdf_info().get("Author"))
+                    return (self._split_authors(raw_author), "pdf_metadata") if raw_author else None
+                if strategy == ExtractionStrategy.DOCLING:
                     for line in lines()[:10]:
-                        a = self._parse_author_line(line)
-                        if len(a) >= 2:
-                            return (a, "docling_heuristic")
-                if s == S.LLM and self._llm_client:
-                    v = llm().get("authors")
-                    return (v, "llm") if v else None
-
-            def _summary(s: S) -> Optional[Tuple[Any, str]]:
-                if s == S.DOCLING:
-                    v = self._find_summary(parsed.doc)
-                    return (v, "docling_heuristic") if v else None
-                if s == S.LLM and self._llm_client:
-                    v = llm().get("summary")
-                    return (v, "llm") if v else None
-
-            def _institute(s: S) -> Optional[Tuple[Any, str]]:
-                if s == S.FILE_METADATA:
-                    raw = self._clean_meta_string(
+                        parsed_authors = self._parse_author_line(line)
+                        if len(parsed_authors) >= 2:
+                            return (parsed_authors, "docling_heuristic")
+                if strategy == ExtractionStrategy.LLM and self._llm_client:
+                    authors = llm().get("authors")
+                    return (authors, "llm") if authors else None
+ 
+            def _extract_summary(strategy: ExtractionStrategy) -> Optional[Tuple[Any, str]]:
+                if strategy == ExtractionStrategy.DOCLING:
+                    summary = self._find_summary(parsed.doc)
+                    return (summary, "docling_heuristic") if summary else None
+                if strategy == ExtractionStrategy.LLM and self._llm_client:
+                    summary = llm().get("summary")
+                    return (summary, "llm") if summary else None
+ 
+            def _extract_institute(strategy: ExtractionStrategy) -> Optional[Tuple[Any, str]]:
+                if strategy == ExtractionStrategy.FILE_METADATA:
+                    raw_name = self._clean_meta_string(
                         pdf_info().get("Producer") or pdf_info().get("Creator")
                     )
-                    if raw and not any(j in raw.lower() for j in _PDF_META_JUNK):
-                        return (Institution(name=raw), "pdf_metadata")
-                if s == S.LLM and self._llm_client:
-                    v = llm().get("publishing_institute")
-                    return (Institution(name=v), "llm") if v else None
-
-            def _acks(s: S) -> Optional[Tuple[Any, str]]:
-                if s == S.LLM and self._llm_client:
-                    items = [
+                    if raw_name and not any(junk in raw_name.lower() for junk in _PDF_META_JUNK):
+                        return (Institution(name=raw_name), "pdf_metadata")
+                if strategy == ExtractionStrategy.LLM and self._llm_client:
+                    institute_name = llm().get("publishing_institute")
+                    return (Institution(name=institute_name), "llm") if institute_name else None
+ 
+            def _extract_acknowledgements(strategy: ExtractionStrategy) -> Optional[Tuple[Any, str]]:
+                if strategy == ExtractionStrategy.LLM and self._llm_client:
+                    acknowledgements = [
                         Acknowledgement(
-                            name=a["name"],
-                            type=a.get("type", ""),
-                            relation=a.get("relation", ""),
+                            name=entry["name"],
+                            type=entry.get("type", ""),
+                            relation=entry.get("relation", ""),
                         )
-                        for a in llm().get("acknowledgements", [])
-                        if a.get("name")
+                        for entry in llm().get("acknowledgements", [])
+                        if entry.get("name")
                     ]
-                    return (items, "llm") if items else None
-
+                    return (acknowledgements, "llm") if acknowledgements else None
+ 
             # ── run each field through its strategy cascade ───────────────
             fields = [
-                (self._config.title,               _title,    "title"),
-                (self._config.authors,             _authors,  "authors"),
-                (self._config.summary,             _summary,  "summary"),
-                (self._config.publishing_institute, _institute, "publishing_institute"),
-                (self._config.acknowledgements,    _acks,     "acknowledgements"),
+                (self._config.title,                _extract_title,            "title"),
+                (self._config.authors,              _extract_authors,          "authors"),
+                (self._config.summary,              _extract_summary,          "summary"),
+                (self._config.publishing_institute, _extract_institute,        "publishing_institute"),
+                (self._config.acknowledgements,     _extract_acknowledgements, "acknowledgements"),
             ]
-
-            for cfg, extractor, attr in fields:
-                if not cfg.enabled:
+ 
+            for field_config, extractor, field_name in fields:
+                if not field_config.enabled:
                     continue
-                for strategy in cfg.strategies.order:
-                    result = extractor(strategy)
-                    if result is not None:
-                        value, source_label = result
-                        setattr(meta, attr, value)
-                        meta.source[attr] = source_label
-                        if cfg.strategies.stop_on_success:
+                for strategy in field_config.strategies.order:
+                    extraction_result = extractor(strategy)
+                    if extraction_result is not None:
+                        extracted_value, source_label = extraction_result
+                        setattr(metadata, field_name, extracted_value)
+                        metadata.source[field_name] = source_label
+                        if field_config.strategies.stop_on_success:
                             break
-
+ 
         except Exception as exc:
             logger.warning(f"Metadata extraction failed for '{pdf_path_str}': {exc}")
-
-        return meta
+ 
+        return metadata
+ 
 
     def _build_llm_client(self) -> Optional[Any]:
         assert self._config is not None
@@ -487,20 +478,20 @@ Text:
     })
 
     @classmethod
-    def _looks_like_title(cls, t: str) -> bool:
-        if len(t) < 8 or "@" in t or len(t.split()) < 2:
+    def _looks_like_title(cls, assumed_title: str) -> bool:
+        if len(assumed_title) < 8 or "@" in assumed_title or len(assumed_title.split()) < 2:
             return False
-        if t == t.upper() and len(t) > 30:
+        if assumed_title == assumed_title.upper() and len(assumed_title) > 30:
             return False
-        return t.strip().lower() not in cls._TITLE_NOISE
+        return assumed_title.strip().lower() not in cls._TITLE_NOISE
 
     @classmethod
     def _first_section_header(cls, doc: Any) -> Optional[str]:
         for node, _ in doc.iterate_items():
             if isinstance(node, SectionHeaderItem):
-                if t := (node.text or "").strip():
-                    if cls._looks_like_title(t):
-                        return t
+                if assumed_title := (node.text or "").strip():
+                    if cls._looks_like_title(assumed_title):
+                        return assumed_title
         return None
 
     @classmethod
@@ -509,57 +500,65 @@ Text:
 
     @staticmethod
     def _find_summary(doc: Any) -> Optional[str]:
-        collecting, collected = False, []
+        collecting = False
+        collected_paragraphs: List[str] = []
         for node, _ in doc.iterate_items():
             if isinstance(node, SectionHeaderItem):
-                h = (node.text or "").strip().lower()
-                if any(k in h for k in _SUMMARY_HEADERS):
+                header_text = (node.text or "").strip().lower()
+                if any(keyword in header_text for keyword in _SUMMARY_HEADERS):
                     collecting = True
                     continue
                 if collecting:
                     break
             if collecting and isinstance(node, TextItem):
-                if t := (node.text or "").strip():
-                    collected.append(t)
-        return "\n".join(collected[:4]) or None
+                paragraph = (node.text or "").strip()
+                if paragraph:
+                    collected_paragraphs.append(paragraph)
+        return "\n".join(collected_paragraphs[:4]) or None
 
     @staticmethod
     def _read_pdf_meta(pdf_path_str: str) -> dict[str, Any]:
         try:
-            if meta := PdfReader(pdf_path_str).metadata:
-                return {k.lstrip("/"): v for k, v in meta.items() if v is not None}
+            embedded_metadata = PdfReader(pdf_path_str).metadata
+            if embedded_metadata:
+                return {
+                    key.lstrip("/"): value
+                    for key, value in embedded_metadata.items()
+                    if value is not None
+                }
         except Exception as exc:
             logger.warning(f"Could not read PDF metadata for '{pdf_path_str}': {exc}")
         return {}
-
+    
     @staticmethod
     def _clean_meta_string(value: Any) -> Optional[str]:
         if value is None:
             return None
-        s = str(value).strip()
-        if not s or s.lower() in _PDF_META_JUNK or s.lower().startswith("microsoft word"):
+        filtered_str = str(value).strip()
+        if not filtered_str or filtered_str.lower() in _PDF_META_JUNK or filtered_str.lower().startswith("microsoft word"):
             return None
-        return s
+        return filtered_str
 
     @staticmethod
-    def _split_authors(s: str) -> List[str]:
-        if ";" in s:
-            parts = [p.strip() for p in s.split(";")]
-        elif re.search(r"\band\b", s, flags=re.I):
-            parts = [p.strip() for p in re.split(r"\band\b", s, flags=re.I)]
+    def _split_authors(author_string: str) -> List[str]:
+        if ";" in author_string:
+            parts = [part.strip() for part in author_string.split(";")]
+        elif re.search(r"\band\b", author_string, flags=re.I):
+            parts = [part.strip() for part in re.split(r"\band\b", author_string, flags=re.I)]
         else:
-            parts = [s.strip()]
-        return [p for p in parts if p]
+            parts = [author_string.strip()]
+        return [part for part in parts if part]
 
     @staticmethod
     def _parse_author_line(text: str) -> List[str]:
         """Parse abbreviated author lines like ``Smith J., Doe A.``"""
-        pattern = re.compile(r"^([A-Z][a-zA-Z\-']+)\s+([A-Z])\.?$")
+        abbreviated_pattern = re.compile(r"^([A-Z][a-zA-Z\-']+)\s+([A-Z])\.?$")
         authors = []
         for part in text.replace(" and ", ",").split(","):
-            if m := pattern.match(part.strip()):
-                last, initial = m.groups()
-                authors.append(f"{initial} {last}")
+            match = abbreviated_pattern.match(part.strip())
+            if match:
+                last_name, initial = match.groups()
+                authors.append(f"{initial} {last_name}")
         return authors
 
     def _chunk(self, *, parsed: ParsedDocument, document_id: str) -> list[Chunk]:
@@ -586,7 +585,7 @@ Text:
         except Exception as exc:
             logger.warning(f"Embedding failed; returning chunks without vectors: {exc}")
             return chunks
-
+ 
     @staticmethod
     def _structural_meta(parsed: Optional[ParsedDocument]) -> dict[str, Any]:
         if parsed is None:
@@ -595,5 +594,6 @@ Text:
             "num_sections":   len(parsed.sections),
             "num_tables":     len(parsed.tables),
             "num_figures":    len(parsed.figures),
-            "section_titles": [t for t, _, _ in parsed.sections if t],
+            "section_titles": [title for title, _, _ in parsed.sections if title],
         }
+ 

--- a/src/database_builder_libs/sources/pdf_source.py
+++ b/src/database_builder_libs/sources/pdf_source.py
@@ -6,7 +6,7 @@ import re
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Optional
+from typing import Any, Dict, List, Mapping, Optional, Tuple
 
 from loguru import logger
 from pydantic import BaseModel, Field, PrivateAttr, field_validator
@@ -26,20 +26,14 @@ from database_builder_libs.utility.extract.document_parser_docling import (
 )
 
 
-# --------------------------------------------------------------------------- #
-# Extracted metadata                                                           #
-# --------------------------------------------------------------------------- #
-
 @dataclasses.dataclass(slots=True)
 class Institution:
-    """A publishing institution."""
     name: str
     parent: Optional[str] = None
 
 
 @dataclasses.dataclass(slots=True)
 class Acknowledgement:
-    """An entity acknowledged in the document."""
     name: str
     type: str      # "person" | "organization" | "group"
     relation: str  # "funding" | "collaboration" | "contribution" | "review" | "support"
@@ -47,39 +41,6 @@ class Acknowledgement:
 
 @dataclasses.dataclass(slots=True)
 class DocumentMetadata:
-    """
-    Rich metadata extracted from a PDF document.
-
-    Produced by :class:`PDFSource` and serialised into
-    ``Content.content["metadata"]`` via ``dataclasses.asdict()``.
-
-    Fields
-    ------
-    title : str | None
-        Document title.
-    authors : list[str] | None
-        Personal author names.
-    publishing_institute : Institution | None
-        Publisher or issuing organisation.
-    summary : str | None
-        Abstract or executive summary text.
-    acknowledgements : list[Acknowledgement]
-        Entities acknowledged in the document.
-    source : dict[str, str]
-        Maps each populated field to the strategy that filled it
-        (e.g. ``{"title": "docling_heuristic", "authors": "llm"}``).
-    keywords : list[str] | None
-        Keywords or tags associated with the document.
-    literature_type : str | None
-        Document type (e.g. ``"report"``, ``"article"``).
-    strategic_overview : list[str] | None
-        Strategic themes extracted from tags.
-    target_groups : list[str] | None
-        Target audience groups extracted from tags.
-    best_practices : list[str] | None
-        Best practice topics extracted from tags.
-    """
-
     title: Optional[str] = None
     authors: Optional[List[str]] = None
     publishing_institute: Optional[Institution] = None
@@ -92,21 +53,13 @@ class DocumentMetadata:
     target_groups: Optional[List[str]] = None
     best_practices: Optional[List[str]] = None
 
-
-# --------------------------------------------------------------------------- #
-# Strategy config                                                              #
-# --------------------------------------------------------------------------- #
-
 class ExtractionStrategy(str, Enum):
-    """Which engine to use when extracting a metadata field."""
-    FILE_METADATA = "file_metadata"  # embedded PDF metadata via pypdf
-    DOCLING       = "docling"        # structural heuristics from Docling IR
-    LLM           = "llm"            # LLM extraction from document header text
+    FILE_METADATA = "file_metadata"
+    DOCLING       = "docling"
+    LLM           = "llm"
 
 
 class OrderedStrategyConfig(BaseModel):
-    """Ordered list of strategies to try for a single metadata field."""
-
     order: List[ExtractionStrategy] = Field(default_factory=list)
     stop_on_success: bool = True
 
@@ -118,38 +71,18 @@ class OrderedStrategyConfig(BaseModel):
 
 
 class FieldExtractionConfig(BaseModel):
-    """Configuration for extracting a single metadata field."""
-
     enabled: bool = True
     strategies: OrderedStrategyConfig = Field(default_factory=OrderedStrategyConfig)
 
 
 class SectionsConfig(BaseModel):
-    """
-    Controls section extraction, chunking, and optional embedding.
-
-    Attributes
-    ----------
-    enabled : bool
-        When ``False`` no chunks are produced.
-    chunking_strategy : AbstractChunkingStrategy
-        Defaults to :class:`SectionChunkingStrategy` (one chunk per section).
-    embedder : AbstractChunkEmbedder | None
-        When set, ``embed()`` is called on all chunks after chunking.
-    """
-
     enabled: bool = True
     chunking_strategy: AbstractChunkingStrategy = Field(
         default_factory=SectionChunkingStrategy
     )
     embedder: Optional[AbstractChunkEmbedder] = None
-
     model_config = {"arbitrary_types_allowed": True}
 
-
-# --------------------------------------------------------------------------- #
-# PDFDocumentConfig                                                            #
-# --------------------------------------------------------------------------- #
 
 class PDFDocumentConfig(BaseModel):
     """
@@ -163,73 +96,22 @@ class PDFDocumentConfig(BaseModel):
     --------------------
     ``FILE_METADATA``
         Reads embedded PDF metadata via ``pypdf`` (fast, no ML).
-        Reliable for title and authors in well-tagged PDFs; often noisy for
-        documents originally produced from Word.
     ``DOCLING``
-        Infers fields from the Docling structural IR: first section header /
-        first plausible line for title; abstract/summary section for summary.
+        Infers fields from the Docling structural IR.
     ``LLM``
-        Sends the first ~60 lines of the document to the configured LLM and
-        parses a JSON response for authors and acknowledgements.
+        Sends the first ~60 lines to the configured LLM.
         Requires ``llm_base_url`` and ``llm_api_key`` to be set.
 
     Defaults
     --------
-    - ``title``   : FILE_METADATA → DOCLING
-    - ``authors`` : FILE_METADATA → LLM
-    - ``summary`` : DOCLING
-    - ``publishing_institute`` : FILE_METADATA
-    - ``acknowledgements`` : LLM
-
-    Usage
-    -----
-    Minimal — only ``folder_path`` is required::
-
-        src = PDFSource()
-        src.connect({"folder_path": "/data/papers"})
-
-    With LLM enrichment for authors::
-
-        src.connect({
-            "folder_path":  "/data/papers",
-            "llm_base_url": "http://localhost:11434/v1",
-            "llm_api_key":  "ollama",
-            "llm_model":    "gemma2:9b",
-        })
-
-    Disable LLM entirely — FILE_METADATA + DOCLING only::
-
-        src.connect({
-            "folder_path": "/data/papers",
-            "authors": FieldExtractionConfig(
-                strategies=OrderedStrategyConfig(
-                    order=[ExtractionStrategy.FILE_METADATA, ExtractionStrategy.DOCLING]
-                )
-            ),
-            "acknowledgements": FieldExtractionConfig(enabled=False),
-        })
-
-    With chunking and embedding::
-
-        from database_builder_libs.utility.chunk.summary_and_sections import SummaryAndSectionsStrategy
-        from database_builder_libs.utility.embed_chunk.openai_compatible import OpenAICompatibleChunkEmbedder
-
-        src.connect({
-            "folder_path": "/data/papers",
-            "sections": SectionsConfig(
-                chunking_strategy=SummaryAndSectionsStrategy(),
-                embedder=OpenAICompatibleChunkEmbedder(
-                    base_url="http://localhost:11434/v1",
-                    api_key="ollama",
-                    model="nomic-embed-text",
-                ),
-            ),
-        })
+    - ``title``               : FILE_METADATA → DOCLING
+    - ``authors``             : FILE_METADATA → LLM
+    - ``summary``             : DOCLING
+    - ``publishing_institute``: FILE_METADATA
+    - ``acknowledgements``    : LLM
     """
 
     folder_path: Path
-
-    # ── metadata field configs ──────────────────────────────────────────────
 
     title: FieldExtractionConfig = Field(
         default_factory=lambda: FieldExtractionConfig(
@@ -238,7 +120,6 @@ class PDFDocumentConfig(BaseModel):
             )
         )
     )
-
     authors: FieldExtractionConfig = Field(
         default_factory=lambda: FieldExtractionConfig(
             strategies=OrderedStrategyConfig(
@@ -246,48 +127,31 @@ class PDFDocumentConfig(BaseModel):
             )
         )
     )
-
     summary: FieldExtractionConfig = Field(
         default_factory=lambda: FieldExtractionConfig(
-            strategies=OrderedStrategyConfig(
-                order=[ExtractionStrategy.DOCLING]
-            )
+            strategies=OrderedStrategyConfig(order=[ExtractionStrategy.DOCLING])
         )
     )
-
     publishing_institute: FieldExtractionConfig = Field(
         default_factory=lambda: FieldExtractionConfig(
-            strategies=OrderedStrategyConfig(
-                order=[ExtractionStrategy.FILE_METADATA]
-            )
+            strategies=OrderedStrategyConfig(order=[ExtractionStrategy.FILE_METADATA])
         )
     )
-
     acknowledgements: FieldExtractionConfig = Field(
         default_factory=lambda: FieldExtractionConfig(
-            strategies=OrderedStrategyConfig(
-                order=[ExtractionStrategy.LLM]
-            )
+            strategies=OrderedStrategyConfig(order=[ExtractionStrategy.LLM])
         )
     )
 
-    # ── section / chunking / embedding ─────────────────────────────────────
-
     sections: SectionsConfig = Field(default_factory=SectionsConfig)
-
-    # ── LLM connection ──────────────────────────────────────────────────────
 
     llm_base_url: Optional[str] = None
     llm_api_key:  Optional[str] = None
     llm_model:    str = "gpt-4.1-mini"
 
 
-# --------------------------------------------------------------------------- #
-# PDFSource                                                                    #
-# --------------------------------------------------------------------------- #
-
-_SUMMARY_HEADERS = frozenset({"abstract", "summary", "executive summary", "samenvatting"})
-_PDF_META_JUNK   = frozenset({"unknown", "untitled", "microsoft word", "writer", "author"})
+_SUMMARY_HEADERS   = frozenset({"abstract", "summary", "executive summary", "samenvatting"})
+_PDF_META_JUNK     = frozenset({"unknown", "untitled", "microsoft word", "writer", "author"})
 _INSTITUTION_HINTS = frozenset({
     "university", "institute", "research", "centre", "center", "group",
     "foundation", "association", "agency", "organisation", "organization",
@@ -317,61 +181,26 @@ class PDFSource(AbstractSource):
         :class:`DocumentMetadata` serialised via ``dataclasses.asdict()``.
     ``chunks``
         List of :class:`~database_builder_libs.models.chunk.Chunk` dicts.
-
-    Synchronisation semantics
-    -------------------------
-    - ``get_list_artefacts()`` uses file-system mtime for incremental sync.
-    - Deletions are not reported.
-    - Identifiers are stable as long as files are not moved.
-
-    Lifecycle
-    ---------
-    ``connect()`` must be called before any other method.
     """
 
-    _config: Optional[PDFDocumentConfig] = PrivateAttr(default=None)
-    _parser: Optional[DocumentParserDocling] = PrivateAttr(default=None)
-    _llm_client: Any = PrivateAttr(default=None)
-
-    # ------------------------------------------------------------------ #
-    # Lifecycle                                                            #
-    # ------------------------------------------------------------------ #
+    _config:     Optional[PDFDocumentConfig]    = PrivateAttr(default=None)
+    _parser:     Optional[DocumentParserDocling] = PrivateAttr(default=None)
+    _llm_client: Any                             = PrivateAttr(default=None)
 
     def _connect_impl(self, config: Mapping[str, Any]) -> None:
-        """
-        Validate config, initialise the Docling parser, and build the LLM
-        client if ``llm_base_url`` and ``llm_api_key`` are provided.
-
-        Raises
-        ------
-        ValueError
-            If ``folder_path`` does not exist or is not a directory.
-        """
         self._config = PDFDocumentConfig(**config)
         if not self._config.folder_path.is_dir():
             raise ValueError(
                 f"folder_path '{self._config.folder_path}' does not exist or is not a directory."
             )
-        self._parser = DocumentParserDocling()
+        self._parser     = DocumentParserDocling()
         self._llm_client = self._build_llm_client()
         logger.info(f"PDFSource connected to folder: {self._config.folder_path}")
 
-    # ------------------------------------------------------------------ #
-    # Public API                                                           #
-    # ------------------------------------------------------------------ #
-
     def get_all_documents_metadata(self, limit: int = -1) -> List[dict[str, Any]]:
-        """
-        Return lightweight file-level metadata for all PDFs in the folder.
-
-        No Docling conversion is performed.  Intended for quick inventory.
-
-        Returns one dict per PDF with keys:
-        ``id``, ``path``, ``size``, ``modified``, ``pdf_meta``.
-        """
+        """Return lightweight file-level metadata for all PDFs (no Docling conversion)."""
         self._ensure_connected()
         assert self._config is not None
-
         results: List[dict[str, Any]] = []
         for pdf_path in sorted(self._config.folder_path.rglob("*.pdf")):
             if limit != -1 and len(results) >= limit:
@@ -386,76 +215,38 @@ class PDFSource(AbstractSource):
             })
         return results
 
-    def get_list_artefacts(
-        self, last_synced: Optional[datetime]
-    ) -> list[tuple[str, datetime]]:
-        """
-        Return PDFs modified after ``last_synced``, sorted ascending by mtime.
-
-        Parameters
-        ----------
-        last_synced : datetime | None
-            UTC timestamp of last sync.  ``None`` returns all files.
-        """
+    def get_list_artefacts(self, last_synced: Optional[datetime]) -> list[tuple[str, datetime]]:
+        """Return PDFs modified after ``last_synced``, sorted ascending by mtime."""
         self._ensure_connected()
         assert self._config is not None
-
         if last_synced is not None and last_synced.tzinfo is None:
             last_synced = last_synced.replace(tzinfo=timezone.utc)
-
-        artefacts: list[tuple[str, datetime]] = []
-        for pdf_path in self._config.folder_path.rglob("*.pdf"):
-            modified = datetime.fromtimestamp(pdf_path.stat().st_mtime, tz=timezone.utc)
-            if last_synced is None or modified > last_synced:
-                artefacts.append((
-                    str(pdf_path.relative_to(self._config.folder_path)),
-                    modified,
-                ))
-
+        artefacts = [
+            (str(p.relative_to(self._config.folder_path)),
+             datetime.fromtimestamp(p.stat().st_mtime, tz=timezone.utc))
+            for p in self._config.folder_path.rglob("*.pdf")
+            if last_synced is None
+            or datetime.fromtimestamp(p.stat().st_mtime, tz=timezone.utc) > last_synced
+        ]
         artefacts.sort(key=lambda t: t[1])
         logger.info(f"get_list_artefacts: {len(artefacts)} PDF(s) since {last_synced}.")
         return artefacts
 
     def get_content(self, artefacts: list[tuple[str, datetime]]) -> list[Content]:
-        """
-        Run the full pipeline for each artefact and return one Content per file.
-
-        Pipeline
-        --------
-        1. **Parse** – Docling converts the PDF to a ``ParsedDocument``.
-        2. **Metadata** – per-field strategy cascade populates
-           :class:`DocumentMetadata`.
-        3. **Chunking** – configured ``AbstractChunkingStrategy`` produces
-           ``Chunk`` objects from the parsed sections.
-        4. **Embedding** – configured ``AbstractChunkEmbedder`` (if any)
-           populates ``Chunk.vector``.
-        5. **Assembly** – everything is packed into ``Content``.
-
-        Errors in any step are caught and logged; a ``Content`` is always
-        returned so one bad file does not abort the batch.
-
-        Raises
-        ------
-        RuntimeError
-            If called before ``connect()``.
-        KeyError
-            If an artefact no longer exists on disk.
-        """
+        """Run the full parse → metadata → chunk → embed pipeline for each artefact."""
         self._ensure_connected()
         assert self._config is not None
         assert self._parser is not None
 
         contents: list[Content] = []
-
         for relative_id, modified in artefacts:
             pdf_path = self._config.folder_path / relative_id
             if not pdf_path.exists():
                 raise KeyError(f"Artefact '{relative_id}' no longer exists.")
 
-            stat        = pdf_path.stat()
+            stat         = pdf_path.stat()
             pdf_path_str = str(pdf_path.resolve())
 
-            # 1. Parse
             parsed: Optional[ParsedDocument] = None
             num_pages: Optional[int] = None
             try:
@@ -466,31 +257,25 @@ class PDFSource(AbstractSource):
             except Exception as exc:
                 logger.warning(f"Unexpected parse error for '{relative_id}': {exc}")
 
-            # 2. Metadata
             metadata = self._extract_metadata(pdf_path_str=pdf_path_str, parsed=parsed)
-
-            # 3. Chunking
-            chunks: list[Chunk] = []
-            if self._config.sections.enabled and parsed is not None:
-                chunks = self._chunk(parsed=parsed, document_id=relative_id)
-
-            # 4. Embedding
+            chunks   = self._chunk(parsed=parsed, document_id=relative_id) if (
+                self._config.sections.enabled and parsed is not None
+            ) else []
             if chunks and self._config.sections.embedder is not None:
                 chunks = self._embed(chunks)
 
-            # 5. Assemble
             contents.append(Content(
                 date=modified,
                 id_=relative_id,
                 content={
-                    "file_path":      pdf_path_str,
-                    "file_name":      pdf_path.name,
-                    "file_size":      stat.st_size,
-                    "num_pages":      num_pages,
-                    "pdf_meta":       self._read_pdf_meta(pdf_path_str),
-                    "metadata":       dataclasses.asdict(metadata),
+                    "file_path":  pdf_path_str,
+                    "file_name":  pdf_path.name,
+                    "file_size":  stat.st_size,
+                    "num_pages":  num_pages,
+                    "pdf_meta":   self._read_pdf_meta(pdf_path_str),
+                    "metadata":   dataclasses.asdict(metadata),
                     **self._structural_meta(parsed),
-                    "chunks":         [dataclasses.asdict(c) for c in chunks],
+                    "chunks":     [dataclasses.asdict(c) for c in chunks],
                 },
             ))
             logger.debug(f"Processed '{relative_id}': {len(chunks)} chunk(s).")
@@ -498,210 +283,155 @@ class PDFSource(AbstractSource):
         logger.info(f"get_content returning {len(contents)} Content object(s).")
         return contents
 
-    # ------------------------------------------------------------------ #
-    # Metadata extraction                                                  #
-    # ------------------------------------------------------------------ #
-
     def _extract_metadata(
-        self,
-        *,
-        pdf_path_str: str,
-        parsed: Optional[ParsedDocument],
+        self, *, pdf_path_str: str, parsed: Optional[ParsedDocument]
     ) -> DocumentMetadata:
         """
-        Populate :class:`DocumentMetadata` by running each field's configured
-        strategy order, stopping on first success per field.
-
-        Each field consults its ``FieldExtractionConfig.strategies.order`` list
-        and calls the matching strategy method:
-
-        - ``FILE_METADATA`` → pypdf embedded metadata
-        - ``DOCLING``       → structural heuristics on the Docling IR
-        - ``LLM``           → JSON extraction via the configured LLM
-
-        Returns an empty :class:`DocumentMetadata` if *parsed* is ``None``
-        (conversion failed) or if all strategies fail.
+        Populate DocumentMetadata by running each field's configured strategy
+        order, stopping on first success when stop_on_success=True.
         """
         assert self._config is not None
         meta = DocumentMetadata()
-
         if parsed is None:
             return meta
 
         try:
-            # Cache expensive operations computed at most once per document.
-            _lines:     Optional[List[str]]  = None
-            _pdf_info:  Optional[Any]        = None
-            _llm_result: Optional[dict[str, Any]] = None
+            # ── lazy, cached accessors ────────────────────────────────────
+            _cache: dict[str, Any] = {}
 
             def lines() -> List[str]:
-                nonlocal _lines
-                if _lines is None:
-                    _lines = self._first_lines(parsed.doc, limit=120)
-                return _lines
+                if "lines" not in _cache:
+                    _cache["lines"] = self._first_lines(parsed.doc, limit=120)
+                return _cache["lines"]
 
-            def pdf_info() -> Any:
-                nonlocal _pdf_info
-                if _pdf_info is None:
+            def pdf_info() -> dict[str, Any]:
+                if "pdf_info" not in _cache:
                     try:
-                        _pdf_info = PdfReader(pdf_path_str).metadata or {}
+                        raw = PdfReader(pdf_path_str).metadata or {}
+                        # raw may be a pypdf DocumentInformation object rather than
+                        # a plain dict — iterate items() but only keep entries whose
+                        # keys are real strings so MagicMock / PrivateAttr objects
+                        # from mismatched pydantic versions are silently dropped.
+                        info: dict[str, Any] = {}
+                        for k, v in raw.items():
+                            if isinstance(k, str):
+                                info[k.lstrip("/")] = v
+                        # Also check well-known attributes directly in case the
+                        # object exposes them as properties (pypdf DocumentInformation).
+                        for attr, key in (("title", "Title"), ("author", "Author"),
+                                          ("producer", "Producer"), ("creator", "Creator")):
+                            if key not in info:
+                                val = getattr(raw, attr, None)
+                                if isinstance(val, str):
+                                    info[key] = val
+                        _cache["pdf_info"] = info
                     except Exception:
-                        _pdf_info = {}
-                return _pdf_info
+                        _cache["pdf_info"] = {}
+                return _cache["pdf_info"]
 
-            def llm_result() -> dict[str, Any]:
-                nonlocal _llm_result
-                if _llm_result is None:
-                    _llm_result = self._call_llm(lines()) if self._llm_client else {}
-                return _llm_result
+            def llm() -> dict[str, Any]:
+                if "llm" not in _cache:
+                    _cache["llm"] = self._call_llm(lines()) if self._llm_client else {}
+                return _cache["llm"]
 
-            # ── title ─────────────────────────────────────────────────────
-            if self._config.title.enabled:
-                for strategy in self._config.title.strategies.order:
-                    if strategy == ExtractionStrategy.FILE_METADATA:
-                        raw = self._clean_meta_string(
-                            getattr(pdf_info(), "title", None)
-                            or pdf_info().get("/Title")
+            # ── per-field extractors: return (value, source_label) or None ─
+            S = ExtractionStrategy
+
+            def _title(s: S) -> Optional[Tuple[Any, str]]:
+                if s == S.FILE_METADATA:
+                    v = self._clean_meta_string(pdf_info().get("Title"))
+                    return (v, "pdf_metadata") if v else None
+                if s == S.DOCLING:
+                    v = self._first_section_header(parsed.doc) or self._first_reasonable_line(lines())
+                    return (v, "docling_heuristic") if v else None
+                if s == S.LLM and self._llm_client:
+                    v = llm().get("title")
+                    return (v, "llm") if v else None
+
+            def _authors(s: S) -> Optional[Tuple[Any, str]]:
+                if s == S.FILE_METADATA:
+                    raw = self._clean_meta_string(pdf_info().get("Author"))
+                    return (self._split_authors(raw), "pdf_metadata") if raw else None
+                if s == S.DOCLING:
+                    for line in lines()[:10]:
+                        a = self._parse_author_line(line)
+                        if len(a) >= 2:
+                            return (a, "docling_heuristic")
+                if s == S.LLM and self._llm_client:
+                    v = llm().get("authors")
+                    return (v, "llm") if v else None
+
+            def _summary(s: S) -> Optional[Tuple[Any, str]]:
+                if s == S.DOCLING:
+                    v = self._find_summary(parsed.doc)
+                    return (v, "docling_heuristic") if v else None
+                if s == S.LLM and self._llm_client:
+                    v = llm().get("summary")
+                    return (v, "llm") if v else None
+
+            def _institute(s: S) -> Optional[Tuple[Any, str]]:
+                if s == S.FILE_METADATA:
+                    raw = self._clean_meta_string(
+                        pdf_info().get("Producer") or pdf_info().get("Creator")
+                    )
+                    if raw and not any(j in raw.lower() for j in _PDF_META_JUNK):
+                        return (Institution(name=raw), "pdf_metadata")
+                if s == S.LLM and self._llm_client:
+                    v = llm().get("publishing_institute")
+                    return (Institution(name=v), "llm") if v else None
+
+            def _acks(s: S) -> Optional[Tuple[Any, str]]:
+                if s == S.LLM and self._llm_client:
+                    items = [
+                        Acknowledgement(
+                            name=a["name"],
+                            type=a.get("type", ""),
+                            relation=a.get("relation", ""),
                         )
-                        if raw:
-                            meta.title = raw
-                            meta.source["title"] = "pdf_metadata"
-                    elif strategy == ExtractionStrategy.DOCLING:
-                        val = self._first_section_header(parsed.doc) \
-                              or self._first_reasonable_line(lines())
-                        if val:
-                            meta.title = val
-                            meta.source["title"] = "docling_heuristic"
-                    elif strategy == ExtractionStrategy.LLM and self._llm_client:
-                        val = llm_result().get("title")
-                        if val:
-                            meta.title = val
-                            meta.source["title"] = "llm"
-                    if meta.title and self._config.title.strategies.stop_on_success:
-                        break
+                        for a in llm().get("acknowledgements", [])
+                        if a.get("name")
+                    ]
+                    return (items, "llm") if items else None
 
-            # ── authors ───────────────────────────────────────────────────
-            if self._config.authors.enabled:
-                for strategy in self._config.authors.strategies.order:
-                    if strategy == ExtractionStrategy.FILE_METADATA:
-                        raw = self._clean_meta_string(
-                            getattr(pdf_info(), "author", None)
-                            or pdf_info().get("/Author")
-                        )
-                        if raw:
-                            meta.authors = self._split_authors(raw)
-                            meta.source["authors"] = "pdf_metadata"
-                    elif strategy == ExtractionStrategy.DOCLING:
-                        for line in lines()[:10]:
-                            parsed_authors = self._parse_author_line(line)
-                            if len(parsed_authors) >= 2:
-                                meta.authors = parsed_authors
-                                meta.source["authors"] = "docling_heuristic"
-                                break
-                    elif strategy == ExtractionStrategy.LLM and self._llm_client:
-                        authors = llm_result().get("authors")
-                        if authors:
-                            meta.authors = authors
-                            meta.source["authors"] = "llm"
-                    if meta.authors and self._config.authors.strategies.stop_on_success:
-                        break
+            # ── run each field through its strategy cascade ───────────────
+            fields = [
+                (self._config.title,               _title,    "title"),
+                (self._config.authors,             _authors,  "authors"),
+                (self._config.summary,             _summary,  "summary"),
+                (self._config.publishing_institute, _institute, "publishing_institute"),
+                (self._config.acknowledgements,    _acks,     "acknowledgements"),
+            ]
 
-            # ── summary ───────────────────────────────────────────────────
-            if self._config.summary.enabled:
-                for strategy in self._config.summary.strategies.order:
-                    if strategy == ExtractionStrategy.DOCLING:
-                        val = self._find_summary(parsed.doc)
-                        if val:
-                            meta.summary = val
-                            meta.source["summary"] = "docling_heuristic"
-                    elif strategy == ExtractionStrategy.LLM and self._llm_client:
-                        val = llm_result().get("summary")
-                        if val:
-                            meta.summary = val
-                            meta.source["summary"] = "llm"
-                    if meta.summary and self._config.summary.strategies.stop_on_success:
-                        break
-
-            # ── publishing_institute ──────────────────────────────────────
-            if self._config.publishing_institute.enabled:
-                for strategy in self._config.publishing_institute.strategies.order:
-                    if strategy == ExtractionStrategy.FILE_METADATA:
-                        raw = self._clean_meta_string(
-                            pdf_info().get("Producer") or pdf_info().get("/Producer")
-                            or pdf_info().get("Creator") or pdf_info().get("/Creator")
-                        )
-                        if raw and not any(j in raw.lower() for j in _PDF_META_JUNK):
-                            meta.publishing_institute = Institution(name=raw)
-                            meta.source["publishing_institute"] = "pdf_metadata"
-                    elif strategy == ExtractionStrategy.LLM and self._llm_client:
-                        val = llm_result().get("publishing_institute")
-                        if val:
-                            meta.publishing_institute = Institution(name=val)
-                            meta.source["publishing_institute"] = "llm"
-                    if meta.publishing_institute and \
-                            self._config.publishing_institute.strategies.stop_on_success:
-                        break
-
-            # ── acknowledgements ──────────────────────────────────────────
-            if self._config.acknowledgements.enabled:
-                for strategy in self._config.acknowledgements.strategies.order:
-                    if strategy == ExtractionStrategy.LLM and self._llm_client:
-                        raw_acks = llm_result().get("acknowledgements", [])
-                        acks = [
-                            Acknowledgement(
-                                name=a.get("name", ""),
-                                type=a.get("type", ""),
-                                relation=a.get("relation", ""),
-                            )
-                            for a in raw_acks
-                            if a.get("name")
-                        ]
-                        if acks:
-                            meta.acknowledgements = acks
-                            meta.source["acknowledgements"] = "llm"
-                    if meta.acknowledgements and \
-                            self._config.acknowledgements.strategies.stop_on_success:
-                        break
+            for cfg, extractor, attr in fields:
+                if not cfg.enabled:
+                    continue
+                for strategy in cfg.strategies.order:
+                    result = extractor(strategy)
+                    if result is not None:
+                        value, source_label = result
+                        setattr(meta, attr, value)
+                        meta.source[attr] = source_label
+                        if cfg.strategies.stop_on_success:
+                            break
 
         except Exception as exc:
             logger.warning(f"Metadata extraction failed for '{pdf_path_str}': {exc}")
 
         return meta
 
-    # ------------------------------------------------------------------ #
-    # LLM                                                                  #
-    # ------------------------------------------------------------------ #
-
     def _build_llm_client(self) -> Optional[Any]:
-        """
-        Instantiate an OpenAI-compatible client from the config, or ``None``.
-
-        Returns ``None`` (with a warning) if ``llm_base_url`` / ``llm_api_key``
-        are unset or if the ``openai`` package is not installed.
-        """
         assert self._config is not None
         if not self._config.llm_base_url or not self._config.llm_api_key:
             return None
         try:
             from openai import OpenAI
-            return OpenAI(
-                base_url=self._config.llm_base_url,
-                api_key=self._config.llm_api_key,
-            )
+            return OpenAI(base_url=self._config.llm_base_url, api_key=self._config.llm_api_key)
         except ImportError:
             logger.warning("openai package not installed; LLM extraction skipped.")
             return None
 
     def _call_llm(self, lines: List[str]) -> dict[str, Any]:
-        """
-        Send the first 60 lines to the LLM and parse the JSON response.
-
-        Returns a dict with keys ``authors``, ``acknowledgements``, and
-        optionally ``summary`` and ``publishing_institute``.  Returns an empty
-        dict on any failure.
-        """
         assert self._config is not None
-        text = "\n".join(lines[:60])
         prompt = f"""Extract metadata from the document header. Return only JSON.
 
 {{
@@ -724,26 +454,20 @@ Rules:
 - Extract acknowledgement entities mentioned in the header or acknowledgements section.
 
 Text:
-{text}
+{chr(10).join(lines[:60])}
 """
         try:
-            res = self._llm_client.chat.completions.create(
+            res     = self._llm_client.chat.completions.create(
                 model=self._config.llm_model,
                 temperature=0,
                 messages=[{"role": "user", "content": prompt}],
             )
             content = res.choices[0].message.content.strip()
-            match = re.search(r"\{.*\}", content, re.S)
-            if not match:
-                return {}
-            return json.loads(match.group(0))
+            match   = re.search(r"\{.*\}", content, re.S)
+            return json.loads(match.group(0)) if match else {}
         except Exception as exc:
             logger.warning(f"LLM call failed: {exc}")
             return {}
-
-    # ------------------------------------------------------------------ #
-    # Docling structural helpers                                           #
-    # ------------------------------------------------------------------ #
 
     @staticmethod
     def _first_lines(doc: Any, limit: int) -> List[str]:
@@ -751,57 +475,41 @@ Text:
         for node, _ in doc.iterate_items():
             if isinstance(node, (SectionHeaderItem, TextItem)):
                 for ln in (node.text or "").strip().splitlines():
-                    ln = ln.strip()
-                    if ln:
+                    if ln := ln.strip():
                         out.append(ln)
                         if len(out) >= limit:
                             return out
         return out
 
-    # Known repository/watermark strings that are not real titles.
     _TITLE_NOISE = frozenset({
-        "university of huddersfield repository",
-        "original citation",
-        "repository",
-        "preprint",
-        "author's accepted manuscript",
-        "accepted manuscript",
-        "post-print",
+        "university of huddersfield repository", "original citation", "repository",
+        "preprint", "author's accepted manuscript", "accepted manuscript", "post-print",
     })
 
     @classmethod
     def _looks_like_title(cls, t: str) -> bool:
-        """Return True if *t* looks like a genuine document title."""
         if len(t) < 8 or "@" in t or len(t.split()) < 2:
             return False
-        # Skip strings that are entirely uppercase — usually section labels,
-        # not titles (the actual title in all-caps will be caught by LLM).
         if t == t.upper() and len(t) > 30:
             return False
-        if t.strip().lower() in cls._TITLE_NOISE:
-            return False
-        return True
+        return t.strip().lower() not in cls._TITLE_NOISE
 
     @classmethod
     def _first_section_header(cls, doc: Any) -> Optional[str]:
         for node, _ in doc.iterate_items():
             if isinstance(node, SectionHeaderItem):
-                t = (node.text or "").strip()
-                if cls._looks_like_title(t):
-                    return t
+                if t := (node.text or "").strip():
+                    if cls._looks_like_title(t):
+                        return t
         return None
 
     @classmethod
     def _first_reasonable_line(cls, lines: List[str]) -> Optional[str]:
-        for ln in lines[:30]:
-            if cls._looks_like_title(ln):
-                return ln
-        return None
+        return next((ln for ln in lines[:30] if cls._looks_like_title(ln)), None)
 
     @staticmethod
     def _find_summary(doc: Any) -> Optional[str]:
-        collecting = False
-        collected: List[str] = []
+        collecting, collected = False, []
         for node, _ in doc.iterate_items():
             if isinstance(node, SectionHeaderItem):
                 h = (node.text or "").strip().lower()
@@ -811,21 +519,15 @@ Text:
                 if collecting:
                     break
             if collecting and isinstance(node, TextItem):
-                t = (node.text or "").strip()
-                if t:
+                if t := (node.text or "").strip():
                     collected.append(t)
         return "\n".join(collected[:4]) or None
-
-    # ------------------------------------------------------------------ #
-    # pypdf / author helpers                                               #
-    # ------------------------------------------------------------------ #
 
     @staticmethod
     def _read_pdf_meta(pdf_path_str: str) -> dict[str, Any]:
         try:
-            reader = PdfReader(pdf_path_str)
-            if reader.metadata:
-                return {k.lstrip("/"): v for k, v in reader.metadata.items() if v is not None}
+            if meta := PdfReader(pdf_path_str).metadata:
+                return {k.lstrip("/"): v for k, v in meta.items() if v is not None}
         except Exception as exc:
             logger.warning(f"Could not read PDF metadata for '{pdf_path_str}': {exc}")
         return {}
@@ -835,10 +537,7 @@ Text:
         if value is None:
             return None
         s = str(value).strip()
-        if not s or s.lower() in _PDF_META_JUNK:
-            return None
-        # reject strings that look like tool-generated titles
-        if s.lower().startswith("microsoft word"):
+        if not s or s.lower() in _PDF_META_JUNK or s.lower().startswith("microsoft word"):
             return None
         return s
 
@@ -855,29 +554,21 @@ Text:
     @staticmethod
     def _parse_author_line(text: str) -> List[str]:
         """Parse abbreviated author lines like ``Smith J., Doe A.``"""
-        text = text.replace(" and ", ",")
-        parts = [p.strip() for p in text.split(",") if p.strip()]
         pattern = re.compile(r"^([A-Z][a-zA-Z\-']+)\s+([A-Z])\.?$")
         authors = []
-        for part in parts:
-            m = pattern.match(part)
-            if m:
+        for part in text.replace(" and ", ",").split(","):
+            if m := pattern.match(part.strip()):
                 last, initial = m.groups()
                 authors.append(f"{initial} {last}")
         return authors
 
-    # ------------------------------------------------------------------ #
-    # Chunking / embedding                                                 #
-    # ------------------------------------------------------------------ #
-
     def _chunk(self, *, parsed: ParsedDocument, document_id: str) -> list[Chunk]:
         assert self._config is not None
         try:
-            summary = self._find_summary(parsed.doc)
             chunks = self._config.sections.chunking_strategy.chunk(
                 parsed.sections,
                 document_id=document_id,
-                summary=summary,
+                summary=self._find_summary(parsed.doc),
             )
             logger.debug(f"Chunked '{document_id}': {len(chunks)} chunk(s).")
             return chunks
@@ -895,10 +586,6 @@ Text:
         except Exception as exc:
             logger.warning(f"Embedding failed; returning chunks without vectors: {exc}")
             return chunks
-
-    # ------------------------------------------------------------------ #
-    # Structural meta                                                      #
-    # ------------------------------------------------------------------ #
 
     @staticmethod
     def _structural_meta(parsed: Optional[ParsedDocument]) -> dict[str, Any]:

--- a/tests/database_builder_libs/sources/pdf/test_pdf_source.py
+++ b/tests/database_builder_libs/sources/pdf/test_pdf_source.py
@@ -1,160 +1,145 @@
+import dataclasses
 import os
-import unittest
+import time
 import tempfile
+import unittest
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Sequence
 from unittest.mock import MagicMock, patch
 
-from pydantic import Field
+import pytest
 
 from database_builder_libs.models.abstract_chunk_embedder import AbstractChunkEmbedder
 from database_builder_libs.models.abstract_chunk_strategy import AbstractChunkingStrategy, RawSection
 from database_builder_libs.models.chunk import Chunk
 from database_builder_libs.sources.pdf_source import (
-    PDFSource,
-    PDFDocumentConfig,
-    SectionsConfig,
+    Acknowledgement,
+    DocumentMetadata,
     ExtractionStrategy,
     FieldExtractionConfig,
+    Institution,
     OrderedStrategyConfig,
+    PDFDocumentConfig,
+    PDFSource,
+    SectionsConfig,
 )
-from database_builder_libs.utility.chunk.n_points_section import SectionChunkingStrategy
+from database_builder_libs.utility.extract.document_parser_docling import (
+    ConversionFault,
+    DocumentConversionError,
+)
+from pydantic import Field
 
 
 # --------------------------------------------------------------------------- #
-# Test helpers                                                                 #
+# Helpers / spies                                                              #
 # --------------------------------------------------------------------------- #
 
 class SpyStrategy(AbstractChunkingStrategy):
-    """
-    Minimal AbstractChunkingStrategy implementation that records every call
-    to chunk() so tests can assert on the arguments it received.
-
-    Used in place of MagicMock where Pydantic's isinstance validation would
-    reject a mock object.
-    """
-
+    """Records chunk() calls; returns empty list."""
     def __init__(self):
         self.calls: list[dict] = []
 
-    def chunk(
-        self,
-        sections: Sequence[RawSection],
-        *,
-        document_id: str,
-        summary: str | None = None,
-    ) -> list[Chunk]:
+    def chunk(self, sections: Sequence[RawSection], *, document_id: str,
+              summary: str | None = None) -> list[Chunk]:
         self.calls.append({"sections": sections, "document_id": document_id, "summary": summary})
         return []
 
 
 class SpyEmbedder(AbstractChunkEmbedder):
-    """
-    Minimal AbstractChunkEmbedder implementation that records calls to embed()
-    and returns chunks with a fixed non-empty vector.
-
-    Used in place of MagicMock where Pydantic's model validation would reject
-    a mock object as the embedder field on SectionsConfig.
-
-    ``received`` is declared as a Pydantic field (not assigned dynamically) so
-    that Pydantic's model validation does not raise on attribute assignment.
-    """
-
+    """Records embed() calls; returns chunks with a fixed vector."""
     received: list[Chunk] = Field(default_factory=list)
-
     model_config = {"arbitrary_types_allowed": True}
 
     def embed(self, chunks: list[Chunk]) -> list[Chunk]:
         self.received = list(chunks)
         return [
-            Chunk(
-                document_id=c.document_id,
-                chunk_index=c.chunk_index,
-                text=c.text,
-                vector=[0.1, 0.2, 0.3],
-                metadata=c.metadata,
-            )
+            Chunk(document_id=c.document_id, chunk_index=c.chunk_index,
+                  text=c.text, vector=[0.1, 0.2, 0.3], metadata=c.metadata)
             for c in chunks
         ]
+
+
+def _make_parsed(sections=None):
+    """Return a ParsedDocument-shaped mock."""
+    parsed = MagicMock()
+    parsed.sections = sections or [
+        ("Introduction", "This is a long enough introduction section.", []),
+        ("Methods",      "The methods section describes the approach taken.", []),
+        ("Abstract",     "This paper presents findings on fuel poverty.", []),
+    ]
+    parsed.tables  = []
+    parsed.figures = []
+    parsed.doc.pages = [MagicMock()]
+    parsed.doc.iterate_items.return_value = iter([])
+    return parsed
+
+
+def _stub_parser(src: PDFSource, parsed=None, fail=False):
+    """Wire src._parser to return *parsed* or raise DocumentConversionError."""
+    src._parser = MagicMock()
+    if fail:
+        src._parser.parse.side_effect = DocumentConversionError(faults=[
+            ConversionFault(faults=[], hashvalue="x", path_file_document=Path("bad.pdf"))
+        ])
+    else:
+        src._parser.parse.return_value = parsed or _make_parsed()
 
 
 class PDFSourceTests(unittest.TestCase):
     """Tests for PDFSource"""
 
-    cwd = os.path.dirname(os.path.realpath(__file__))
-
-    # ---------------------------------------------------------------------- #
-    # Helpers                                                                 #
-    # ---------------------------------------------------------------------- #
-
-    def connect_source(self, folder: str | Path, **extra) -> PDFSource:
-        """Connect a PDFSource to *folder* with the parser mocked out."""
-        src = PDFSource()
-        src.connect({"folder_path": str(folder), **extra})
-        # Replace the real Docling parser with a mock so tests stay fast
-        # and do not require ML models to be installed.
-        src._parser = MagicMock()
-        return src
-
-    def make_parsed_document(
-        self,
-        sections: list | None = None,
-        num_pages: int = 3,
-    ) -> MagicMock:
-        """Return a ParsedDocument-shaped mock with sensible defaults."""
-        parsed = MagicMock()
-        parsed.sections = sections or [
-            ("Introduction", "This is the introduction text of the document.", []),
-            ("Methods", "The methods section describes the approach taken.", []),
-            ("Results", "The results section presents the findings.", []),
-        ]
-        parsed.tables = []
-        parsed.figures = []
-        parsed.footnotes = []
-        parsed.furniture = []
-        parsed.doc.pages = [MagicMock()] * num_pages
-        return parsed
-
-    def write_dummy_pdf(self, folder: Path, name: str = "paper.pdf") -> Path:
-        """Write a zero-byte placeholder so rglob finds a PDF file."""
-        path = folder / name
-        path.write_bytes(b"")
-        return path
+    # ------------------------------------------------------------------ #
+    # Fixtures                                                             #
+    # ------------------------------------------------------------------ #
 
     def setUp(self):
         self._tmpdir = tempfile.TemporaryDirectory()
-        self.folder = Path(self._tmpdir.name)
+        self.folder  = Path(self._tmpdir.name)
 
     def tearDown(self):
         self._tmpdir.cleanup()
 
-    # ---------------------------------------------------------------------- #
-    # connect / _connect_impl                                                 #
-    # ---------------------------------------------------------------------- #
+    def connect(self, extra: dict | None = None) -> PDFSource:
+        """Connect a PDFSource with the Docling parser mocked out."""
+        src = PDFSource()
+        src.connect({"folder_path": str(self.folder), **(extra or {})})
+        _stub_parser(src)
+        return src
+
+    def write_pdf(self, name: str = "paper.pdf") -> Path:
+        p = self.folder / name
+        p.write_bytes(b"")
+        return p
+
+    def ts(self) -> datetime:
+        return datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+    # ------------------------------------------------------------------ #
+    # connect / lifecycle                                                  #
+    # ------------------------------------------------------------------ #
 
     def test_connect_succeeds_with_valid_folder(self):
-        """connect() must not raise when folder_path points to an existing directory."""
+        """connect() must not raise for an existing directory."""
         src = PDFSource()
         src.connect({"folder_path": str(self.folder)})
-        # No exception raised — connection was successful.
 
     def test_connect_raises_on_missing_folder(self):
         """connect() must raise ValueError when folder_path does not exist."""
         src = PDFSource()
         with self.assertRaises(ValueError):
-            src.connect({"folder_path": "/this/path/does/not/exist"})
+            src.connect({"folder_path": "/does/not/exist"})
 
     def test_connect_is_idempotent(self):
-        """Calling connect() twice must not raise or re-initialise the parser."""
+        """Calling connect() twice must not re-initialise the parser."""
         src = PDFSource()
         src.connect({"folder_path": str(self.folder)})
-        parser_after_first = src._parser
+        parser_id = id(src._parser)
         src.connect({"folder_path": str(self.folder)})
-        self.assertIs(src._parser, parser_after_first)
+        self.assertEqual(id(src._parser), parser_id)
 
     def test_methods_raise_before_connect(self):
-        """All public methods must raise RuntimeError when called before connect()."""
+        """All public methods must raise RuntimeError before connect()."""
         src = PDFSource()
         with self.assertRaises(RuntimeError):
             src.get_list_artefacts(None)
@@ -163,414 +148,446 @@ class PDFSourceTests(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             src.get_all_documents_metadata()
 
-    # ---------------------------------------------------------------------- #
-    # get_all_documents_metadata                                              #
-    # ---------------------------------------------------------------------- #
+    # ------------------------------------------------------------------ #
+    # get_list_artefacts                                                   #
+    # ------------------------------------------------------------------ #
 
-    def test_get_all_documents_metadata_returns_one_entry_per_pdf(self):
-        """get_all_documents_metadata() must return exactly one dict per PDF found.
+    def test_list_returns_all_when_last_synced_is_none(self):
+        """None last_synced must return every PDF discovered."""
+        self.write_pdf("a.pdf")
+        self.write_pdf("b.pdf")
+        src = self.connect()
+        self.assertEqual(len(src.get_list_artefacts(None)), 2)
 
-        The method scans the folder recursively and reads pypdf metadata without
-        performing any Docling conversion.  This test verifies the scan logic and
-        the structure of the returned dicts.
-        """
-        self.write_dummy_pdf(self.folder, "paper_a.pdf")
-        self.write_dummy_pdf(self.folder, "paper_b.pdf")
-
-        src = self.connect_source(self.folder)
-        results = src.get_all_documents_metadata()
-
-        self.assertEqual(len(results), 2)
-
-    def test_get_all_documents_metadata_dict_keys(self):
-        """Each metadata dict must contain the mandatory keys."""
-        self.write_dummy_pdf(self.folder)
-        src = self.connect_source(self.folder)
-        result = src.get_all_documents_metadata()[0]
-
-        for key in ("id", "path", "size", "modified", "pdf_meta"):
-            self.assertIn(key, result)
-
-    def test_get_all_documents_metadata_id_is_relative_path(self):
-        """The ``id`` key must be the path relative to folder_path, not absolute."""
-        sub = self.folder / "subdir"
-        sub.mkdir()
-        self.write_dummy_pdf(sub, "nested.pdf")
-
-        src = self.connect_source(self.folder)
-        result = src.get_all_documents_metadata()[0]
-
-        self.assertEqual(result["id"], "subdir/nested.pdf")
-        self.assertFalse(result["id"].startswith("/"))
-
-    def test_get_all_documents_metadata_limit(self):
-        """The ``limit`` parameter must cap the number of returned entries."""
-        for name in ("a.pdf", "b.pdf", "c.pdf"):
-            self.write_dummy_pdf(self.folder, name)
-
-        src = self.connect_source(self.folder)
-        results = src.get_all_documents_metadata(limit=2)
-
-        self.assertEqual(len(results), 2)
-
-    def test_get_all_documents_metadata_modified_is_utc_aware(self):
-        """The ``modified`` field must be a timezone-aware UTC datetime."""
-        self.write_dummy_pdf(self.folder)
-        src = self.connect_source(self.folder)
-        result = src.get_all_documents_metadata()[0]
-
-        self.assertIsNotNone(result["modified"].tzinfo)
-
-    # ---------------------------------------------------------------------- #
-    # get_list_artefacts                                                      #
-    # ---------------------------------------------------------------------- #
-
-    def test_get_list_artefacts_returns_all_when_last_synced_is_none(self):
-        """When last_synced is None, all PDFs in the folder must be returned.
-
-        This mirrors the initial-sync behaviour: with no prior checkpoint every
-        discovered file is treated as new.
-        """
-        self.write_dummy_pdf(self.folder, "doc1.pdf")
-        self.write_dummy_pdf(self.folder, "doc2.pdf")
-
-        src = self.connect_source(self.folder)
-        artefacts = src.get_list_artefacts(None)
-
-        self.assertEqual(len(artefacts), 2)
-
-    def test_get_list_artefacts_returns_tuples_of_str_and_datetime(self):
-        """Each artefact must be a (str, datetime) tuple with a stable string ID."""
-        self.write_dummy_pdf(self.folder)
-        src = self.connect_source(self.folder)
-        artefacts = src.get_list_artefacts(None)
-
-        self.assertIsInstance(artefacts[0][0], str)
-        self.assertIsInstance(artefacts[0][1], datetime)
-
-    def test_get_list_artefacts_ids_are_relative_paths(self):
-        """Artefact IDs must be relative to folder_path, not absolute."""
-        self.write_dummy_pdf(self.folder, "relative.pdf")
-        src = self.connect_source(self.folder)
-        artefact_id = src.get_list_artefacts(None)[0][0]
-
-        self.assertFalse(artefact_id.startswith("/"))
-        self.assertEqual(artefact_id, "relative.pdf")
-
-    def test_get_list_artefacts_sorted_ascending_by_mtime(self):
-        """Artefacts must be sorted by modification time, oldest first."""
-        import time
-
-        old = self.write_dummy_pdf(self.folder, "old.pdf")
-        time.sleep(0.05)
-        new = self.write_dummy_pdf(self.folder, "new.pdf")
-
-        src = self.connect_source(self.folder)
-        artefacts = src.get_list_artefacts(None)
-
-        ids = [a[0] for a in artefacts]
-        self.assertEqual(ids.index("old.pdf") < ids.index("new.pdf"), True)
-
-    def test_get_list_artefacts_filters_by_last_synced(self):
-        """Only files modified strictly after last_synced must be returned.
-
-        This is the incremental-sync path: files that predate the checkpoint
-        should be excluded so they are not reprocessed unnecessarily.
-        """
-        self.write_dummy_pdf(self.folder, "existing.pdf")
-
-        future = datetime(9999, 1, 1, tzinfo=timezone.utc)
-        src = self.connect_source(self.folder)
-        artefacts = src.get_list_artefacts(future)
-
-        self.assertEqual(len(artefacts), 0)
-
-    def test_get_list_artefacts_timestamps_are_utc_aware(self):
-        """Returned timestamps must be timezone-aware (UTC)."""
-        self.write_dummy_pdf(self.folder)
-        src = self.connect_source(self.folder)
-        _, ts = src.get_list_artefacts(None)[0]
-
-        self.assertIsNotNone(ts.tzinfo)
-
-    def test_get_list_artefacts_scans_subdirectories(self):
-        """PDFs in subdirectories must be discovered."""
+    def test_list_ids_are_relative_paths(self):
+        """Artefact IDs must be relative to folder_path."""
         sub = self.folder / "sub"
         sub.mkdir()
-        self.write_dummy_pdf(sub, "deep.pdf")
-
-        src = self.connect_source(self.folder)
+        (sub / "deep.pdf").write_bytes(b"")
+        src = self.connect()
         ids = [a[0] for a in src.get_list_artefacts(None)]
-
         self.assertIn("sub/deep.pdf", ids)
+        self.assertFalse(any(i.startswith("/") for i in ids))
 
-    # ---------------------------------------------------------------------- #
-    # get_content                                                             #
-    # ---------------------------------------------------------------------- #
+    def test_list_sorted_ascending_by_mtime(self):
+        """Artefacts must be ordered oldest-first."""
+        old = self.write_pdf("old.pdf")
+        time.sleep(0.05)
+        self.write_pdf("new.pdf")
+        src = self.connect()
+        ids = [a[0] for a in src.get_list_artefacts(None)]
+        self.assertLess(ids.index("old.pdf"), ids.index("new.pdf"))
 
-    def test_get_content_returns_one_content_per_artefact(self):
-        """get_content() must return exactly one Content object per input artefact.
+    def test_list_filters_by_last_synced(self):
+        """Files older than last_synced must be excluded."""
+        self.write_pdf()
+        src = self.connect()
+        future = datetime(9999, 1, 1, tzinfo=timezone.utc)
+        self.assertEqual(src.get_list_artefacts(future), [])
 
-        This test verifies the basic contract of the method: every artefact that
-        enters must produce a corresponding Content, even if Docling conversion
-        fails.  The parser is mocked to return a well-formed ParsedDocument.
-        """
-        pdf = self.write_dummy_pdf(self.folder)
-        src = self.connect_source(self.folder)
-        src._parser.parse.return_value = self.make_parsed_document()
+    def test_list_timestamps_are_utc_aware(self):
+        self.write_pdf()
+        src = self.connect()
+        _, ts = src.get_list_artefacts(None)[0]
+        self.assertIsNotNone(ts.tzinfo)
 
-        artefacts = [(pdf.name, datetime(2024, 1, 1, tzinfo=timezone.utc))]
-        contents = src.get_content(artefacts)
+    # ------------------------------------------------------------------ #
+    # get_content — pipeline wiring                                        #
+    # ------------------------------------------------------------------ #
 
+    def test_get_content_returns_one_per_artefact(self):
+        """One Content object must be returned per input artefact."""
+        pdf = self.write_pdf()
+        src = self.connect()
+        contents = src.get_content([(pdf.name, self.ts())])
         self.assertEqual(len(contents), 1)
 
-    def test_get_content_id_matches_artefact_key(self):
-        """Content.id_ must equal the relative path provided in the artefact tuple."""
-        pdf = self.write_dummy_pdf(self.folder)
-        src = self.connect_source(self.folder)
-        src._parser.parse.return_value = self.make_parsed_document()
+    def test_get_content_id_and_date(self):
+        """Content.id_ and Content.date must match the artefact tuple."""
+        pdf = self.write_pdf()
+        src = self.connect()
+        ts  = self.ts()
+        c   = src.get_content([(pdf.name, ts)])[0]
+        self.assertEqual(c.id_,  pdf.name)
+        self.assertEqual(c.date, ts)
 
-        artefacts = [(pdf.name, datetime(2024, 1, 1, tzinfo=timezone.utc))]
-        content = src.get_content(artefacts)[0]
-
-        self.assertEqual(content.id_, pdf.name)
-
-    def test_get_content_date_matches_artefact_timestamp(self):
-        """Content.date must match the timestamp supplied in the artefact tuple.
-
-        The date reflects the mtime observed during listing, not the time the
-        content was retrieved, so that incremental sync cursors stay accurate.
-        """
-        pdf = self.write_dummy_pdf(self.folder)
-        src = self.connect_source(self.folder)
-        src._parser.parse.return_value = self.make_parsed_document()
-
-        expected_date = datetime(2024, 6, 15, tzinfo=timezone.utc)
-        content = src.get_content([(pdf.name, expected_date)])[0]
-
-        self.assertEqual(content.date, expected_date)
-
-    def test_get_content_payload_contains_required_keys(self):
-        """Content.content must contain all mandatory payload keys."""
-        pdf = self.write_dummy_pdf(self.folder)
-        src = self.connect_source(self.folder)
-        src._parser.parse.return_value = self.make_parsed_document()
-
-        content = src.get_content([(pdf.name, datetime(2024, 1, 1, tzinfo=timezone.utc))])[0]
-
-        for key in ("file_path", "file_name", "file_size", "num_pages", "pdf_meta",
-                    "num_sections", "num_tables", "num_figures", "section_titles", "chunks"):
-            self.assertIn(key, content.content, f"Missing key: {key}")
-
-    def test_get_content_chunks_produced_from_sections(self):
-        """When sections are present, chunks must be produced by the chunking strategy.
-
-        This test verifies the end-to-end wiring between DocumentParserDocling
-        and the chunking strategy: sections from the ParsedDocument flow through
-        SectionChunkingStrategy and end up serialised in Content.content["chunks"].
-        """
-        pdf = self.write_dummy_pdf(self.folder)
-        src = self.connect_source(self.folder)
-        src._parser.parse.return_value = self.make_parsed_document()
-
-        content = src.get_content([(pdf.name, datetime(2024, 1, 1, tzinfo=timezone.utc))])[0]
-
-        self.assertGreater(len(content.content["chunks"]), 0)
-
-    def test_get_content_chunks_are_serialised_dicts(self):
-        """Chunks in Content.content must be plain dicts (model_dump output), not Chunk objects."""
-        pdf = self.write_dummy_pdf(self.folder)
-        src = self.connect_source(self.folder)
-        src._parser.parse.return_value = self.make_parsed_document()
-
-        content = src.get_content([(pdf.name, datetime(2024, 1, 1, tzinfo=timezone.utc))])[0]
-        chunks = content.content["chunks"]
-
-        self.assertIsInstance(chunks[0], dict)
-        self.assertIn("document_id", chunks[0])
-        self.assertIn("chunk_index", chunks[0])
-        self.assertIn("text", chunks[0])
-
-    def test_get_content_calls_embedder_when_configured(self):
-        """When an embedder is configured, embed() must be called with the produced chunks.
-
-        This test verifies the wiring between the chunking step and the embedding
-        step by checking that the embedder's embed() method is called with a
-        non-empty list of Chunk objects.
-        """
-        pdf = self.write_dummy_pdf(self.folder)
-
-        spy_embedder = SpyEmbedder()
-
-        src = PDFSource()
-        src.connect({
-            "folder_path": str(self.folder),
-            "sections": SectionsConfig(embedder=spy_embedder),
-        })
-        src._parser = MagicMock()
-        src._parser.parse.return_value = self.make_parsed_document()
-
-        src.get_content([(pdf.name, datetime(2024, 1, 1, tzinfo=timezone.utc))])
-
-        self.assertGreater(len(spy_embedder.received), 0, "embed() was never called")
-        self.assertIsInstance(spy_embedder.received[0], Chunk)
-
-    def test_get_content_skips_embedder_when_not_configured(self):
-        """When no embedder is configured, chunks must have empty vectors.
-
-        This verifies the default behaviour: embedding is opt-in and the
-        pipeline must produce usable text-only chunks without an embedder.
-        """
-        pdf = self.write_dummy_pdf(self.folder)
-        src = self.connect_source(self.folder)
-        src._parser.parse.return_value = self.make_parsed_document()
-
-        content = src.get_content([(pdf.name, datetime(2024, 1, 1, tzinfo=timezone.utc))])[0]
-
-        for chunk in content.content["chunks"]:
-            self.assertEqual(chunk["vector"], [])
+    def test_get_content_payload_keys(self):
+        """Content.content must contain all required keys."""
+        pdf = self.write_pdf()
+        src = self.connect()
+        payload = src.get_content([(pdf.name, self.ts())])[0].content
+        for key in ("file_path", "file_name", "file_size", "num_pages",
+                    "pdf_meta", "metadata", "chunks",
+                    "num_sections", "num_tables", "num_figures", "section_titles"):
+            self.assertIn(key, payload, f"Missing key: {key}")
 
     def test_get_content_raises_key_error_for_missing_file(self):
-        """get_content() must raise KeyError when an artefact path no longer exists.
-
-        This guards against the race condition where a file is deleted between
-        listing and retrieval.
-        """
-        src = self.connect_source(self.folder)
-        artefacts = [("ghost.pdf", datetime(2024, 1, 1, tzinfo=timezone.utc))]
-
+        """KeyError must be raised when an artefact file no longer exists."""
+        src = self.connect()
         with self.assertRaises(KeyError):
-            src.get_content(artefacts)
+            src.get_content([("ghost.pdf", self.ts())])
 
     def test_get_content_continues_after_conversion_failure(self):
-        """A DocumentConversionError on one file must not abort the whole batch.
+        """A conversion failure on one file must not abort the batch."""
+        ok_pdf  = self.write_pdf("ok.pdf")
+        bad_pdf = self.write_pdf("bad.pdf")
 
-        The pipeline must still return a Content object for the failed file,
-        with empty chunks, so that a single bad PDF does not prevent the rest
-        of the batch from being processed.
-        """
-        pdf_ok  = self.write_dummy_pdf(self.folder, "ok.pdf")
-        pdf_bad = self.write_dummy_pdf(self.folder, "bad.pdf")
+        src = PDFSource()
+        src.connect({"folder_path": str(self.folder)})
 
-        src = self.connect_source(self.folder)
-
-        from database_builder_libs.utility.extract.document_parser_docling import (
-            ConversionFault, DocumentConversionError,
-        )
-
-        def parse_side_effect(path: str):
+        def side_effect(path: str):
             if "bad" in path:
                 raise DocumentConversionError(faults=[
-                    ConversionFault(faults=[], hashvalue="x", path_file_document=Path(path))
+                    ConversionFault(faults=[], hashvalue="x",
+                                    path_file_document=Path(path))
                 ])
-            return self.make_parsed_document()
+            return _make_parsed()
 
-        src._parser.parse.side_effect = parse_side_effect
+        src._parser = MagicMock()
+        src._parser.parse.side_effect = side_effect
 
-        ts = datetime(2024, 1, 1, tzinfo=timezone.utc)
-        contents = src.get_content([(pdf_ok.name, ts), (pdf_bad.name, ts)])
-
+        ts       = self.ts()
+        contents = src.get_content([(ok_pdf.name, ts), (bad_pdf.name, ts)])
         self.assertEqual(len(contents), 2)
-        bad_content = next(c for c in contents if c.id_ == "bad.pdf")
-        self.assertEqual(bad_content.content["chunks"], [])
+        bad = next(c for c in contents if c.id_ == "bad.pdf")
+        self.assertEqual(bad.content["chunks"], [])
 
-    def test_get_content_structural_meta_reflects_parsed_document(self):
-        """Structural metadata counts must match the sections/tables/figures in ParsedDocument."""
-        pdf = self.write_dummy_pdf(self.folder)
-        src = self.connect_source(self.folder)
-
-        parsed = self.make_parsed_document(sections=[
-            ("Introduction", "Intro text padded to be long enough.", []),
-            ("Methods",      "Methods text padded to be long enough.", [MagicMock()]),
-        ])
-        parsed.tables  = [MagicMock(), MagicMock()]
-        parsed.figures = [MagicMock()]
+    def test_get_content_chunks_are_dicts(self):
+        """Chunks in Content.content must be plain dicts (asdict output)."""
+        pdf = self.write_pdf()
+        spy = SpyStrategy()
+        spy.calls  # pre-touch
+        src = PDFSource()
+        src.connect({
+            "folder_path": str(self.folder),
+            "sections": SectionsConfig(
+                chunking_strategy=spy,
+            ),
+        })
+        # Give the spy something to produce
+        src._parser = MagicMock()
+        parsed = _make_parsed()
         src._parser.parse.return_value = parsed
+        # Override spy to return real chunks
+        spy.chunk = lambda sections, *, document_id, summary=None: [
+            Chunk(document_id=document_id, chunk_index=0,
+                  text="hello world text", vector=[])
+        ]
+        payload = src.get_content([(self.write_pdf().name, self.ts())])[0].content
+        self.assertIsInstance(payload["chunks"][0], dict)
+        self.assertIn("document_id", payload["chunks"][0])
 
-        content = src.get_content([(pdf.name, datetime(2024, 1, 1, tzinfo=timezone.utc))])[0]
-
-        self.assertEqual(content.content["num_sections"], 2)
-        self.assertEqual(content.content["num_tables"],   2)
-        self.assertEqual(content.content["num_figures"],  1)
-
-    def test_get_content_section_titles_in_metadata(self):
-        """section_titles must list non-empty section headers from the parsed document."""
-        pdf = self.write_dummy_pdf(self.folder)
-        src = self.connect_source(self.folder)
-        src._parser.parse.return_value = self.make_parsed_document(sections=[
-            ("Background", "Background text long enough to chunk.", []),
-            ("",           "Untitled preamble text long enough.",   []),
-        ])
-
-        content = src.get_content([(pdf.name, datetime(2024, 1, 1, tzinfo=timezone.utc))])[0]
-
-        self.assertIn("Background", content.content["section_titles"])
-        self.assertNotIn("", content.content["section_titles"])
-
-    def test_get_content_uses_abstract_section_as_summary(self):
-        """A section titled 'abstract' must be forwarded as the summary to the chunking strategy.
-
-        This test verifies that _find_summary() correctly identifies the abstract
-        section and that it reaches the chunking strategy via the summary kwarg,
-        enabling strategies like SummaryAndSectionsStrategy to prepend it.
-        """
-        pdf = self.write_dummy_pdf(self.folder)
-
-        spy = SpyStrategy()
-
-        src = PDFSource()
-        src.connect({
-            "folder_path": str(self.folder),
-            "sections": SectionsConfig(chunking_strategy=spy),
-        })
-        src._parser = MagicMock()
-        src._parser.parse.return_value = self.make_parsed_document(sections=[
-            ("Abstract", "This is the abstract of the paper.", []),
-            ("Methods",  "This is the methods section text.",  []),
-        ])
-
-        src.get_content([(pdf.name, datetime(2024, 1, 1, tzinfo=timezone.utc))])
-
-        self.assertEqual(len(spy.calls), 1)
-        self.assertEqual(spy.calls[0]["summary"], "This is the abstract of the paper.")
-
-    def test_get_content_no_summary_when_no_abstract_section(self):
-        """summary kwarg must be None when no abstract/summary section is present."""
-        pdf = self.write_dummy_pdf(self.folder)
-
-        spy = SpyStrategy()
-
-        src = PDFSource()
-        src.connect({
-            "folder_path": str(self.folder),
-            "sections": SectionsConfig(chunking_strategy=spy),
-        })
-        src._parser = MagicMock()
-        src._parser.parse.return_value = self.make_parsed_document(sections=[
-            ("Introduction", "Introduction text long enough.", []),
-            ("Conclusion",   "Conclusion text long enough.",   []),
-        ])
-
-        src.get_content([(pdf.name, datetime(2024, 1, 1, tzinfo=timezone.utc))])
-
-        self.assertEqual(len(spy.calls), 1)
-        self.assertIsNone(spy.calls[0]["summary"])
-
-    def test_get_content_sections_disabled_produces_no_chunks(self):
-        """When sections.enabled is False, Content.content["chunks"] must be empty."""
-        pdf = self.write_dummy_pdf(self.folder)
-
+    def test_sections_disabled_produces_no_chunks(self):
+        """sections.enabled=False must result in an empty chunks list."""
+        pdf = self.write_pdf()
         src = PDFSource()
         src.connect({
             "folder_path": str(self.folder),
             "sections": SectionsConfig(enabled=False),
         })
-        src._parser = MagicMock()
-        src._parser.parse.return_value = self.make_parsed_document()
+        _stub_parser(src)
+        payload = src.get_content([(pdf.name, self.ts())])[0].content
+        self.assertEqual(payload["chunks"], [])
 
-        content = src.get_content([(pdf.name, datetime(2024, 1, 1, tzinfo=timezone.utc))])[0]
+    def test_embedder_called_when_configured(self):
+        """The configured embedder must receive the produced chunks."""
+        spy_embedder = SpyEmbedder()
 
-        self.assertEqual(content.content["chunks"], [])
+        # Use a strategy that actually produces chunks
+        class OneChunkStrategy(AbstractChunkingStrategy):
+            def chunk(self, sections, *, document_id, summary=None):
+                return [Chunk(document_id=document_id, chunk_index=0,
+                              text="section body text here", vector=[])]
+
+        pdf = self.write_pdf()
+        src = PDFSource()
+        src.connect({
+            "folder_path": str(self.folder),
+            "sections": SectionsConfig(
+                chunking_strategy=OneChunkStrategy(),
+                embedder=spy_embedder,
+            ),
+        })
+        _stub_parser(src)
+        src.get_content([(pdf.name, self.ts())])
+        self.assertGreater(len(spy_embedder.received), 0)
+        self.assertIsInstance(spy_embedder.received[0], Chunk)
+
+    def test_embedder_not_called_when_none(self):
+        """Chunks must have empty vectors when no embedder is configured."""
+        class OneChunkStrategy(AbstractChunkingStrategy):
+            def chunk(self, sections, *, document_id, summary=None):
+                return [Chunk(document_id=document_id, chunk_index=0,
+                              text="section body text here", vector=[])]
+
+        pdf = self.write_pdf()
+        src = PDFSource()
+        src.connect({
+            "folder_path": str(self.folder),
+            "sections": SectionsConfig(chunking_strategy=OneChunkStrategy()),
+        })
+        _stub_parser(src)
+        chunks = src.get_content([(pdf.name, self.ts())])[0].content["chunks"]
+        self.assertTrue(all(c["vector"] == [] for c in chunks))
+
+    # ------------------------------------------------------------------ #
+    # Metadata — strategy dispatch                                         #
+    # ------------------------------------------------------------------ #
+
+    def _src_with_llm(self, llm_payload: dict, **extra_config) -> tuple[PDFSource, Path]:
+        """
+        Return a connected PDFSource whose LLM client returns *llm_payload*,
+        together with a dummy PDF path.
+        """
+        pdf = self.write_pdf()
+        src = PDFSource()
+        src.connect({"folder_path": str(self.folder), **extra_config})
+        _stub_parser(src)
+        src._llm_client = MagicMock()
+        src._llm_client.chat.completions.create.return_value = MagicMock(
+            choices=[MagicMock(message=MagicMock(
+                content=__import__("json").dumps(llm_payload)
+            ))]
+        )
+        return src, pdf
+
+    def test_title_llm_strategy(self):
+        """LLM strategy must populate title from llm_result['title']."""
+        src, pdf = self._src_with_llm(
+            {"title": "The Real Title", "authors": [], "acknowledgements": []},
+            title=FieldExtractionConfig(
+                strategies=OrderedStrategyConfig(order=[ExtractionStrategy.LLM])
+            ),
+        )
+        meta = src.get_content([(pdf.name, self.ts())])[0].content["metadata"]
+        self.assertEqual(meta["title"], "The Real Title")
+        self.assertEqual(meta["source"]["title"], "llm")
+
+    def test_title_docling_strategy(self):
+        """DOCLING strategy must find title from the first section header."""
+        from unittest.mock import patch as _patch
+        pdf = self.write_pdf()
+        src = PDFSource()
+        src.connect({
+            "folder_path": str(self.folder),
+            "title": FieldExtractionConfig(
+                strategies=OrderedStrategyConfig(order=[ExtractionStrategy.DOCLING])
+            ),
+        })
+        _stub_parser(src)
+
+        with _patch.object(PDFSource, "_first_section_header", return_value="Section Title Here"):
+            meta = src.get_content([(pdf.name, self.ts())])[0].content["metadata"]
+
+        self.assertEqual(meta["title"], "Section Title Here")
+        self.assertEqual(meta["source"]["title"], "docling_heuristic")
+
+    def test_authors_llm_overwrites_file_metadata(self):
+        """With stop_on_success=False, LLM must overwrite FILE_METADATA authors."""
+        src, pdf = self._src_with_llm(
+            {"authors": ["Real Author"], "acknowledgements": []},
+            authors=FieldExtractionConfig(
+                strategies=OrderedStrategyConfig(
+                    order=[ExtractionStrategy.FILE_METADATA, ExtractionStrategy.LLM],
+                    stop_on_success=False,
+                )
+            ),
+        )
+        fake_info = MagicMock()
+        fake_info.get.side_effect = lambda key, *_: "Tool User" if key in ("/Author", "Author") else None
+        fake_info.author = "Tool User"
+        with patch("database_builder_libs.sources.pdf_source.PdfReader") as mock_reader:
+            mock_reader.return_value.metadata = fake_info
+            meta = src.get_content([(pdf.name, self.ts())])[0].content["metadata"]
+
+        self.assertEqual(meta["authors"], ["Real Author"])
+        self.assertEqual(meta["source"]["authors"], "llm")
+
+    def test_authors_stop_on_success_prevents_llm(self):
+        """With stop_on_success=True, a successful FILE_METADATA must block LLM."""
+        src, pdf = self._src_with_llm(
+            {"authors": ["LLM Author"], "acknowledgements": []},
+            authors=FieldExtractionConfig(
+                strategies=OrderedStrategyConfig(
+                    order=[ExtractionStrategy.FILE_METADATA, ExtractionStrategy.LLM],
+                    stop_on_success=True,
+                )
+            ),
+        )
+        # Patch PdfReader so pdf_info() returns a real author via FILE_METADATA.
+        fake_info = MagicMock()
+        fake_info.get.side_effect = lambda key, *_: "File Author" if key in ("/Author", "Author") else None
+        fake_info.author = "File Author"
+        with patch("database_builder_libs.sources.pdf_source.PdfReader") as mock_reader:
+            mock_reader.return_value.metadata = fake_info
+            meta = src.get_content([(pdf.name, self.ts())])[0].content["metadata"]
+
+        self.assertEqual(meta["authors"], ["File Author"])
+        self.assertEqual(meta["source"]["authors"], "pdf_metadata")
+
+    def test_summary_docling_strategy(self):
+        """DOCLING summary strategy must pick up the abstract section body."""
+        pdf = self.write_pdf()
+        src = PDFSource()
+        src.connect({
+            "folder_path": str(self.folder),
+            "summary": FieldExtractionConfig(
+                strategies=OrderedStrategyConfig(order=[ExtractionStrategy.DOCLING])
+            ),
+        })
+        parsed = _make_parsed(sections=[
+            ("Abstract", "This is the abstract text of the document.", []),
+            ("Methods",  "Method details here.", []),
+        ])
+        _stub_parser(src, parsed=parsed)
+
+        with patch.object(PDFSource, "_find_summary",
+                          return_value="This is the abstract text of the document."):
+            meta = src.get_content([(pdf.name, self.ts())])[0].content["metadata"]
+
+        self.assertEqual(meta["summary"], "This is the abstract text of the document.")
+        self.assertEqual(meta["source"]["summary"], "docling_heuristic")
+
+    def test_publishing_institute_llm_strategy(self):
+        """LLM strategy must populate publishing_institute."""
+        src, pdf = self._src_with_llm(
+            {"publishing_institute": "University Press", "authors": [], "acknowledgements": []},
+            publishing_institute=FieldExtractionConfig(
+                strategies=OrderedStrategyConfig(order=[ExtractionStrategy.LLM])
+            ),
+        )
+        meta = src.get_content([(pdf.name, self.ts())])[0].content["metadata"]
+        self.assertEqual(meta["publishing_institute"]["name"], "University Press")
+        self.assertEqual(meta["source"]["publishing_institute"], "llm")
+
+    def test_acknowledgements_llm_strategy(self):
+        """LLM strategy must populate acknowledgements list."""
+        src, pdf = self._src_with_llm(
+            {
+                "authors": [],
+                "acknowledgements": [
+                    {"name": "NEARG", "type": "organization", "relation": "collaboration"}
+                ],
+            },
+            acknowledgements=FieldExtractionConfig(
+                strategies=OrderedStrategyConfig(order=[ExtractionStrategy.LLM])
+            ),
+        )
+        meta = src.get_content([(pdf.name, self.ts())])[0].content["metadata"]
+        self.assertEqual(len(meta["acknowledgements"]), 1)
+        self.assertEqual(meta["acknowledgements"][0]["name"], "NEARG")
+        self.assertEqual(meta["source"]["acknowledgements"], "llm")
+
+    def test_field_disabled_skips_extraction(self):
+        """A field with enabled=False must produce no value and no source entry."""
+        src, pdf = self._src_with_llm(
+            {"title": "Should Not Appear", "authors": [], "acknowledgements": []},
+            title=FieldExtractionConfig(enabled=False),
+        )
+        meta = src.get_content([(pdf.name, self.ts())])[0].content["metadata"]
+        self.assertIsNone(meta["title"])
+        self.assertNotIn("title", meta["source"])
+
+    def test_llm_not_called_when_not_configured(self):
+        """LLM call must not be made when llm_base_url/llm_api_key are absent."""
+        pdf = self.write_pdf()
+        src = PDFSource()
+        src.connect({
+            "folder_path": str(self.folder),
+            "authors": FieldExtractionConfig(
+                strategies=OrderedStrategyConfig(order=[ExtractionStrategy.LLM])
+            ),
+        })
+        _stub_parser(src)
+        # No llm_client set — _call_llm must never be reached.
+        self.assertIsNone(src._llm_client)
+        meta = src.get_content([(pdf.name, self.ts())])[0].content["metadata"]
+        self.assertIsNone(meta["authors"])
+
+    def test_llm_called_once_even_for_multiple_fields(self):
+        """The LLM must be invoked at most once per document regardless of how many fields need it."""
+        src, pdf = self._src_with_llm(
+            {"title": "T", "authors": ["A"], "publishing_institute": "P",
+             "acknowledgements": []},
+            title=FieldExtractionConfig(
+                strategies=OrderedStrategyConfig(order=[ExtractionStrategy.LLM])
+            ),
+            authors=FieldExtractionConfig(
+                strategies=OrderedStrategyConfig(order=[ExtractionStrategy.LLM])
+            ),
+            publishing_institute=FieldExtractionConfig(
+                strategies=OrderedStrategyConfig(order=[ExtractionStrategy.LLM])
+            ),
+        )
+        src.get_content([(pdf.name, self.ts())])
+        self.assertEqual(
+            src._llm_client.chat.completions.create.call_count, 1,
+            "LLM was called more than once for a single document",
+        )
+
+    # ------------------------------------------------------------------ #
+    # Metadata — helpers                                                   #
+    # ------------------------------------------------------------------ #
+
+    def test_split_authors_semicolon(self):
+        self.assertEqual(
+            PDFSource._split_authors("Smith J.; Doe A."),
+            ["Smith J.", "Doe A."],
+        )
+
+    def test_split_authors_and(self):
+        self.assertEqual(
+            PDFSource._split_authors("Smith J. and Doe A."),
+            ["Smith J.", "Doe A."],
+        )
+
+    def test_clean_meta_string_rejects_word_noise(self):
+        self.assertIsNone(PDFSource._clean_meta_string("Microsoft Word - document.doc"))
+
+    def test_clean_meta_string_accepts_real_title(self):
+        self.assertEqual(
+            PDFSource._clean_meta_string("  A Real Title  "),
+            "A Real Title",
+        )
+
+    def test_clean_meta_string_rejects_junk(self):
+        for junk in ("unknown", "untitled", "author"):
+            self.assertIsNone(PDFSource._clean_meta_string(junk))
+
+    def test_parse_author_line_abbreviated(self):
+        result = PDFSource._parse_author_line("Smith J., Doe A.")
+        self.assertEqual(result, ["J Smith", "A Doe"])
+
+    def test_parse_author_line_no_match(self):
+        self.assertEqual(PDFSource._parse_author_line("not an author line"), [])
+
+    # ------------------------------------------------------------------ #
+    # DocumentMetadata                                                     #
+    # ------------------------------------------------------------------ #
+
+    def test_document_metadata_default_fields(self):
+        """All optional fields must default to None / empty."""
+        meta = DocumentMetadata()
+        self.assertIsNone(meta.title)
+        self.assertIsNone(meta.authors)
+        self.assertIsNone(meta.summary)
+        self.assertIsNone(meta.publishing_institute)
+        self.assertEqual(meta.acknowledgements, [])
+        self.assertEqual(meta.source, {})
+        self.assertIsNone(meta.keywords)
+
+    def test_document_metadata_asdict_is_serialisable(self):
+        """dataclasses.asdict() on DocumentMetadata must produce a JSON-serialisable dict."""
+        import json
+        meta = DocumentMetadata(
+            title="Test",
+            authors=["Author A"],
+            publishing_institute=Institution(name="Press"),
+            acknowledgements=[Acknowledgement(name="Group", type="organization", relation="funding")],
+            source={"title": "llm"},
+        )
+        d = dataclasses.asdict(meta)
+        json.dumps(d)  # must not raise
 
 
 if __name__ == "__main__":

--- a/tests/database_builder_libs/sources/pdf/test_pdf_source.py
+++ b/tests/database_builder_libs/sources/pdf/test_pdf_source.py
@@ -1,0 +1,577 @@
+import os
+import unittest
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Sequence
+from unittest.mock import MagicMock, patch
+
+from pydantic import Field
+
+from database_builder_libs.models.abstract_chunk_embedder import AbstractChunkEmbedder
+from database_builder_libs.models.abstract_chunk_strategy import AbstractChunkingStrategy, RawSection
+from database_builder_libs.models.chunk import Chunk
+from database_builder_libs.sources.pdf_source import (
+    PDFSource,
+    PDFDocumentConfig,
+    SectionsConfig,
+    ExtractionStrategy,
+    FieldExtractionConfig,
+    OrderedStrategyConfig,
+)
+from database_builder_libs.utility.chunk.n_points_section import SectionChunkingStrategy
+
+
+# --------------------------------------------------------------------------- #
+# Test helpers                                                                 #
+# --------------------------------------------------------------------------- #
+
+class SpyStrategy(AbstractChunkingStrategy):
+    """
+    Minimal AbstractChunkingStrategy implementation that records every call
+    to chunk() so tests can assert on the arguments it received.
+
+    Used in place of MagicMock where Pydantic's isinstance validation would
+    reject a mock object.
+    """
+
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    def chunk(
+        self,
+        sections: Sequence[RawSection],
+        *,
+        document_id: str,
+        summary: str | None = None,
+    ) -> list[Chunk]:
+        self.calls.append({"sections": sections, "document_id": document_id, "summary": summary})
+        return []
+
+
+class SpyEmbedder(AbstractChunkEmbedder):
+    """
+    Minimal AbstractChunkEmbedder implementation that records calls to embed()
+    and returns chunks with a fixed non-empty vector.
+
+    Used in place of MagicMock where Pydantic's model validation would reject
+    a mock object as the embedder field on SectionsConfig.
+
+    ``received`` is declared as a Pydantic field (not assigned dynamically) so
+    that Pydantic's model validation does not raise on attribute assignment.
+    """
+
+    received: list[Chunk] = Field(default_factory=list)
+
+    model_config = {"arbitrary_types_allowed": True}
+
+    def embed(self, chunks: list[Chunk]) -> list[Chunk]:
+        self.received = list(chunks)
+        return [
+            Chunk(
+                document_id=c.document_id,
+                chunk_index=c.chunk_index,
+                text=c.text,
+                vector=[0.1, 0.2, 0.3],
+                metadata=c.metadata,
+            )
+            for c in chunks
+        ]
+
+
+class PDFSourceTests(unittest.TestCase):
+    """Tests for PDFSource"""
+
+    cwd = os.path.dirname(os.path.realpath(__file__))
+
+    # ---------------------------------------------------------------------- #
+    # Helpers                                                                 #
+    # ---------------------------------------------------------------------- #
+
+    def connect_source(self, folder: str | Path, **extra) -> PDFSource:
+        """Connect a PDFSource to *folder* with the parser mocked out."""
+        src = PDFSource()
+        src.connect({"folder_path": str(folder), **extra})
+        # Replace the real Docling parser with a mock so tests stay fast
+        # and do not require ML models to be installed.
+        src._parser = MagicMock()
+        return src
+
+    def make_parsed_document(
+        self,
+        sections: list | None = None,
+        num_pages: int = 3,
+    ) -> MagicMock:
+        """Return a ParsedDocument-shaped mock with sensible defaults."""
+        parsed = MagicMock()
+        parsed.sections = sections or [
+            ("Introduction", "This is the introduction text of the document.", []),
+            ("Methods", "The methods section describes the approach taken.", []),
+            ("Results", "The results section presents the findings.", []),
+        ]
+        parsed.tables = []
+        parsed.figures = []
+        parsed.footnotes = []
+        parsed.furniture = []
+        parsed.doc.pages = [MagicMock()] * num_pages
+        return parsed
+
+    def write_dummy_pdf(self, folder: Path, name: str = "paper.pdf") -> Path:
+        """Write a zero-byte placeholder so rglob finds a PDF file."""
+        path = folder / name
+        path.write_bytes(b"")
+        return path
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.folder = Path(self._tmpdir.name)
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+
+    # ---------------------------------------------------------------------- #
+    # connect / _connect_impl                                                 #
+    # ---------------------------------------------------------------------- #
+
+    def test_connect_succeeds_with_valid_folder(self):
+        """connect() must not raise when folder_path points to an existing directory."""
+        src = PDFSource()
+        src.connect({"folder_path": str(self.folder)})
+        # No exception raised — connection was successful.
+
+    def test_connect_raises_on_missing_folder(self):
+        """connect() must raise ValueError when folder_path does not exist."""
+        src = PDFSource()
+        with self.assertRaises(ValueError):
+            src.connect({"folder_path": "/this/path/does/not/exist"})
+
+    def test_connect_is_idempotent(self):
+        """Calling connect() twice must not raise or re-initialise the parser."""
+        src = PDFSource()
+        src.connect({"folder_path": str(self.folder)})
+        parser_after_first = src._parser
+        src.connect({"folder_path": str(self.folder)})
+        self.assertIs(src._parser, parser_after_first)
+
+    def test_methods_raise_before_connect(self):
+        """All public methods must raise RuntimeError when called before connect()."""
+        src = PDFSource()
+        with self.assertRaises(RuntimeError):
+            src.get_list_artefacts(None)
+        with self.assertRaises(RuntimeError):
+            src.get_content([])
+        with self.assertRaises(RuntimeError):
+            src.get_all_documents_metadata()
+
+    # ---------------------------------------------------------------------- #
+    # get_all_documents_metadata                                              #
+    # ---------------------------------------------------------------------- #
+
+    def test_get_all_documents_metadata_returns_one_entry_per_pdf(self):
+        """get_all_documents_metadata() must return exactly one dict per PDF found.
+
+        The method scans the folder recursively and reads pypdf metadata without
+        performing any Docling conversion.  This test verifies the scan logic and
+        the structure of the returned dicts.
+        """
+        self.write_dummy_pdf(self.folder, "paper_a.pdf")
+        self.write_dummy_pdf(self.folder, "paper_b.pdf")
+
+        src = self.connect_source(self.folder)
+        results = src.get_all_documents_metadata()
+
+        self.assertEqual(len(results), 2)
+
+    def test_get_all_documents_metadata_dict_keys(self):
+        """Each metadata dict must contain the mandatory keys."""
+        self.write_dummy_pdf(self.folder)
+        src = self.connect_source(self.folder)
+        result = src.get_all_documents_metadata()[0]
+
+        for key in ("id", "path", "size", "modified", "pdf_meta"):
+            self.assertIn(key, result)
+
+    def test_get_all_documents_metadata_id_is_relative_path(self):
+        """The ``id`` key must be the path relative to folder_path, not absolute."""
+        sub = self.folder / "subdir"
+        sub.mkdir()
+        self.write_dummy_pdf(sub, "nested.pdf")
+
+        src = self.connect_source(self.folder)
+        result = src.get_all_documents_metadata()[0]
+
+        self.assertEqual(result["id"], "subdir/nested.pdf")
+        self.assertFalse(result["id"].startswith("/"))
+
+    def test_get_all_documents_metadata_limit(self):
+        """The ``limit`` parameter must cap the number of returned entries."""
+        for name in ("a.pdf", "b.pdf", "c.pdf"):
+            self.write_dummy_pdf(self.folder, name)
+
+        src = self.connect_source(self.folder)
+        results = src.get_all_documents_metadata(limit=2)
+
+        self.assertEqual(len(results), 2)
+
+    def test_get_all_documents_metadata_modified_is_utc_aware(self):
+        """The ``modified`` field must be a timezone-aware UTC datetime."""
+        self.write_dummy_pdf(self.folder)
+        src = self.connect_source(self.folder)
+        result = src.get_all_documents_metadata()[0]
+
+        self.assertIsNotNone(result["modified"].tzinfo)
+
+    # ---------------------------------------------------------------------- #
+    # get_list_artefacts                                                      #
+    # ---------------------------------------------------------------------- #
+
+    def test_get_list_artefacts_returns_all_when_last_synced_is_none(self):
+        """When last_synced is None, all PDFs in the folder must be returned.
+
+        This mirrors the initial-sync behaviour: with no prior checkpoint every
+        discovered file is treated as new.
+        """
+        self.write_dummy_pdf(self.folder, "doc1.pdf")
+        self.write_dummy_pdf(self.folder, "doc2.pdf")
+
+        src = self.connect_source(self.folder)
+        artefacts = src.get_list_artefacts(None)
+
+        self.assertEqual(len(artefacts), 2)
+
+    def test_get_list_artefacts_returns_tuples_of_str_and_datetime(self):
+        """Each artefact must be a (str, datetime) tuple with a stable string ID."""
+        self.write_dummy_pdf(self.folder)
+        src = self.connect_source(self.folder)
+        artefacts = src.get_list_artefacts(None)
+
+        self.assertIsInstance(artefacts[0][0], str)
+        self.assertIsInstance(artefacts[0][1], datetime)
+
+    def test_get_list_artefacts_ids_are_relative_paths(self):
+        """Artefact IDs must be relative to folder_path, not absolute."""
+        self.write_dummy_pdf(self.folder, "relative.pdf")
+        src = self.connect_source(self.folder)
+        artefact_id = src.get_list_artefacts(None)[0][0]
+
+        self.assertFalse(artefact_id.startswith("/"))
+        self.assertEqual(artefact_id, "relative.pdf")
+
+    def test_get_list_artefacts_sorted_ascending_by_mtime(self):
+        """Artefacts must be sorted by modification time, oldest first."""
+        import time
+
+        old = self.write_dummy_pdf(self.folder, "old.pdf")
+        time.sleep(0.05)
+        new = self.write_dummy_pdf(self.folder, "new.pdf")
+
+        src = self.connect_source(self.folder)
+        artefacts = src.get_list_artefacts(None)
+
+        ids = [a[0] for a in artefacts]
+        self.assertEqual(ids.index("old.pdf") < ids.index("new.pdf"), True)
+
+    def test_get_list_artefacts_filters_by_last_synced(self):
+        """Only files modified strictly after last_synced must be returned.
+
+        This is the incremental-sync path: files that predate the checkpoint
+        should be excluded so they are not reprocessed unnecessarily.
+        """
+        self.write_dummy_pdf(self.folder, "existing.pdf")
+
+        future = datetime(9999, 1, 1, tzinfo=timezone.utc)
+        src = self.connect_source(self.folder)
+        artefacts = src.get_list_artefacts(future)
+
+        self.assertEqual(len(artefacts), 0)
+
+    def test_get_list_artefacts_timestamps_are_utc_aware(self):
+        """Returned timestamps must be timezone-aware (UTC)."""
+        self.write_dummy_pdf(self.folder)
+        src = self.connect_source(self.folder)
+        _, ts = src.get_list_artefacts(None)[0]
+
+        self.assertIsNotNone(ts.tzinfo)
+
+    def test_get_list_artefacts_scans_subdirectories(self):
+        """PDFs in subdirectories must be discovered."""
+        sub = self.folder / "sub"
+        sub.mkdir()
+        self.write_dummy_pdf(sub, "deep.pdf")
+
+        src = self.connect_source(self.folder)
+        ids = [a[0] for a in src.get_list_artefacts(None)]
+
+        self.assertIn("sub/deep.pdf", ids)
+
+    # ---------------------------------------------------------------------- #
+    # get_content                                                             #
+    # ---------------------------------------------------------------------- #
+
+    def test_get_content_returns_one_content_per_artefact(self):
+        """get_content() must return exactly one Content object per input artefact.
+
+        This test verifies the basic contract of the method: every artefact that
+        enters must produce a corresponding Content, even if Docling conversion
+        fails.  The parser is mocked to return a well-formed ParsedDocument.
+        """
+        pdf = self.write_dummy_pdf(self.folder)
+        src = self.connect_source(self.folder)
+        src._parser.parse.return_value = self.make_parsed_document()
+
+        artefacts = [(pdf.name, datetime(2024, 1, 1, tzinfo=timezone.utc))]
+        contents = src.get_content(artefacts)
+
+        self.assertEqual(len(contents), 1)
+
+    def test_get_content_id_matches_artefact_key(self):
+        """Content.id_ must equal the relative path provided in the artefact tuple."""
+        pdf = self.write_dummy_pdf(self.folder)
+        src = self.connect_source(self.folder)
+        src._parser.parse.return_value = self.make_parsed_document()
+
+        artefacts = [(pdf.name, datetime(2024, 1, 1, tzinfo=timezone.utc))]
+        content = src.get_content(artefacts)[0]
+
+        self.assertEqual(content.id_, pdf.name)
+
+    def test_get_content_date_matches_artefact_timestamp(self):
+        """Content.date must match the timestamp supplied in the artefact tuple.
+
+        The date reflects the mtime observed during listing, not the time the
+        content was retrieved, so that incremental sync cursors stay accurate.
+        """
+        pdf = self.write_dummy_pdf(self.folder)
+        src = self.connect_source(self.folder)
+        src._parser.parse.return_value = self.make_parsed_document()
+
+        expected_date = datetime(2024, 6, 15, tzinfo=timezone.utc)
+        content = src.get_content([(pdf.name, expected_date)])[0]
+
+        self.assertEqual(content.date, expected_date)
+
+    def test_get_content_payload_contains_required_keys(self):
+        """Content.content must contain all mandatory payload keys."""
+        pdf = self.write_dummy_pdf(self.folder)
+        src = self.connect_source(self.folder)
+        src._parser.parse.return_value = self.make_parsed_document()
+
+        content = src.get_content([(pdf.name, datetime(2024, 1, 1, tzinfo=timezone.utc))])[0]
+
+        for key in ("file_path", "file_name", "file_size", "num_pages", "pdf_meta",
+                    "num_sections", "num_tables", "num_figures", "section_titles", "chunks"):
+            self.assertIn(key, content.content, f"Missing key: {key}")
+
+    def test_get_content_chunks_produced_from_sections(self):
+        """When sections are present, chunks must be produced by the chunking strategy.
+
+        This test verifies the end-to-end wiring between DocumentParserDocling
+        and the chunking strategy: sections from the ParsedDocument flow through
+        SectionChunkingStrategy and end up serialised in Content.content["chunks"].
+        """
+        pdf = self.write_dummy_pdf(self.folder)
+        src = self.connect_source(self.folder)
+        src._parser.parse.return_value = self.make_parsed_document()
+
+        content = src.get_content([(pdf.name, datetime(2024, 1, 1, tzinfo=timezone.utc))])[0]
+
+        self.assertGreater(len(content.content["chunks"]), 0)
+
+    def test_get_content_chunks_are_serialised_dicts(self):
+        """Chunks in Content.content must be plain dicts (model_dump output), not Chunk objects."""
+        pdf = self.write_dummy_pdf(self.folder)
+        src = self.connect_source(self.folder)
+        src._parser.parse.return_value = self.make_parsed_document()
+
+        content = src.get_content([(pdf.name, datetime(2024, 1, 1, tzinfo=timezone.utc))])[0]
+        chunks = content.content["chunks"]
+
+        self.assertIsInstance(chunks[0], dict)
+        self.assertIn("document_id", chunks[0])
+        self.assertIn("chunk_index", chunks[0])
+        self.assertIn("text", chunks[0])
+
+    def test_get_content_calls_embedder_when_configured(self):
+        """When an embedder is configured, embed() must be called with the produced chunks.
+
+        This test verifies the wiring between the chunking step and the embedding
+        step by checking that the embedder's embed() method is called with a
+        non-empty list of Chunk objects.
+        """
+        pdf = self.write_dummy_pdf(self.folder)
+
+        spy_embedder = SpyEmbedder()
+
+        src = PDFSource()
+        src.connect({
+            "folder_path": str(self.folder),
+            "sections": SectionsConfig(embedder=spy_embedder),
+        })
+        src._parser = MagicMock()
+        src._parser.parse.return_value = self.make_parsed_document()
+
+        src.get_content([(pdf.name, datetime(2024, 1, 1, tzinfo=timezone.utc))])
+
+        self.assertGreater(len(spy_embedder.received), 0, "embed() was never called")
+        self.assertIsInstance(spy_embedder.received[0], Chunk)
+
+    def test_get_content_skips_embedder_when_not_configured(self):
+        """When no embedder is configured, chunks must have empty vectors.
+
+        This verifies the default behaviour: embedding is opt-in and the
+        pipeline must produce usable text-only chunks without an embedder.
+        """
+        pdf = self.write_dummy_pdf(self.folder)
+        src = self.connect_source(self.folder)
+        src._parser.parse.return_value = self.make_parsed_document()
+
+        content = src.get_content([(pdf.name, datetime(2024, 1, 1, tzinfo=timezone.utc))])[0]
+
+        for chunk in content.content["chunks"]:
+            self.assertEqual(chunk["vector"], [])
+
+    def test_get_content_raises_key_error_for_missing_file(self):
+        """get_content() must raise KeyError when an artefact path no longer exists.
+
+        This guards against the race condition where a file is deleted between
+        listing and retrieval.
+        """
+        src = self.connect_source(self.folder)
+        artefacts = [("ghost.pdf", datetime(2024, 1, 1, tzinfo=timezone.utc))]
+
+        with self.assertRaises(KeyError):
+            src.get_content(artefacts)
+
+    def test_get_content_continues_after_conversion_failure(self):
+        """A DocumentConversionError on one file must not abort the whole batch.
+
+        The pipeline must still return a Content object for the failed file,
+        with empty chunks, so that a single bad PDF does not prevent the rest
+        of the batch from being processed.
+        """
+        pdf_ok  = self.write_dummy_pdf(self.folder, "ok.pdf")
+        pdf_bad = self.write_dummy_pdf(self.folder, "bad.pdf")
+
+        src = self.connect_source(self.folder)
+
+        from database_builder_libs.utility.extract.document_parser_docling import (
+            ConversionFault, DocumentConversionError,
+        )
+
+        def parse_side_effect(path: str):
+            if "bad" in path:
+                raise DocumentConversionError(faults=[
+                    ConversionFault(faults=[], hashvalue="x", path_file_document=Path(path))
+                ])
+            return self.make_parsed_document()
+
+        src._parser.parse.side_effect = parse_side_effect
+
+        ts = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        contents = src.get_content([(pdf_ok.name, ts), (pdf_bad.name, ts)])
+
+        self.assertEqual(len(contents), 2)
+        bad_content = next(c for c in contents if c.id_ == "bad.pdf")
+        self.assertEqual(bad_content.content["chunks"], [])
+
+    def test_get_content_structural_meta_reflects_parsed_document(self):
+        """Structural metadata counts must match the sections/tables/figures in ParsedDocument."""
+        pdf = self.write_dummy_pdf(self.folder)
+        src = self.connect_source(self.folder)
+
+        parsed = self.make_parsed_document(sections=[
+            ("Introduction", "Intro text padded to be long enough.", []),
+            ("Methods",      "Methods text padded to be long enough.", [MagicMock()]),
+        ])
+        parsed.tables  = [MagicMock(), MagicMock()]
+        parsed.figures = [MagicMock()]
+        src._parser.parse.return_value = parsed
+
+        content = src.get_content([(pdf.name, datetime(2024, 1, 1, tzinfo=timezone.utc))])[0]
+
+        self.assertEqual(content.content["num_sections"], 2)
+        self.assertEqual(content.content["num_tables"],   2)
+        self.assertEqual(content.content["num_figures"],  1)
+
+    def test_get_content_section_titles_in_metadata(self):
+        """section_titles must list non-empty section headers from the parsed document."""
+        pdf = self.write_dummy_pdf(self.folder)
+        src = self.connect_source(self.folder)
+        src._parser.parse.return_value = self.make_parsed_document(sections=[
+            ("Background", "Background text long enough to chunk.", []),
+            ("",           "Untitled preamble text long enough.",   []),
+        ])
+
+        content = src.get_content([(pdf.name, datetime(2024, 1, 1, tzinfo=timezone.utc))])[0]
+
+        self.assertIn("Background", content.content["section_titles"])
+        self.assertNotIn("", content.content["section_titles"])
+
+    def test_get_content_uses_abstract_section_as_summary(self):
+        """A section titled 'abstract' must be forwarded as the summary to the chunking strategy.
+
+        This test verifies that _find_summary() correctly identifies the abstract
+        section and that it reaches the chunking strategy via the summary kwarg,
+        enabling strategies like SummaryAndSectionsStrategy to prepend it.
+        """
+        pdf = self.write_dummy_pdf(self.folder)
+
+        spy = SpyStrategy()
+
+        src = PDFSource()
+        src.connect({
+            "folder_path": str(self.folder),
+            "sections": SectionsConfig(chunking_strategy=spy),
+        })
+        src._parser = MagicMock()
+        src._parser.parse.return_value = self.make_parsed_document(sections=[
+            ("Abstract", "This is the abstract of the paper.", []),
+            ("Methods",  "This is the methods section text.",  []),
+        ])
+
+        src.get_content([(pdf.name, datetime(2024, 1, 1, tzinfo=timezone.utc))])
+
+        self.assertEqual(len(spy.calls), 1)
+        self.assertEqual(spy.calls[0]["summary"], "This is the abstract of the paper.")
+
+    def test_get_content_no_summary_when_no_abstract_section(self):
+        """summary kwarg must be None when no abstract/summary section is present."""
+        pdf = self.write_dummy_pdf(self.folder)
+
+        spy = SpyStrategy()
+
+        src = PDFSource()
+        src.connect({
+            "folder_path": str(self.folder),
+            "sections": SectionsConfig(chunking_strategy=spy),
+        })
+        src._parser = MagicMock()
+        src._parser.parse.return_value = self.make_parsed_document(sections=[
+            ("Introduction", "Introduction text long enough.", []),
+            ("Conclusion",   "Conclusion text long enough.",   []),
+        ])
+
+        src.get_content([(pdf.name, datetime(2024, 1, 1, tzinfo=timezone.utc))])
+
+        self.assertEqual(len(spy.calls), 1)
+        self.assertIsNone(spy.calls[0]["summary"])
+
+    def test_get_content_sections_disabled_produces_no_chunks(self):
+        """When sections.enabled is False, Content.content["chunks"] must be empty."""
+        pdf = self.write_dummy_pdf(self.folder)
+
+        src = PDFSource()
+        src.connect({
+            "folder_path": str(self.folder),
+            "sections": SectionsConfig(enabled=False),
+        })
+        src._parser = MagicMock()
+        src._parser.parse.return_value = self.make_parsed_document()
+
+        content = src.get_content([(pdf.name, datetime(2024, 1, 1, tzinfo=timezone.utc))])[0]
+
+        self.assertEqual(content.content["chunks"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/database_builder_libs/sources/pdf/test_pdf_source.py
+++ b/tests/database_builder_libs/sources/pdf/test_pdf_source.py
@@ -31,10 +31,6 @@ from database_builder_libs.utility.extract.document_parser_docling import (
 from pydantic import Field
 
 
-# --------------------------------------------------------------------------- #
-# Helpers / spies                                                              #
-# --------------------------------------------------------------------------- #
-
 class SpyStrategy(AbstractChunkingStrategy):
     """Records chunk() calls; returns empty list."""
     def __init__(self):
@@ -89,10 +85,6 @@ def _stub_parser(src: PDFSource, parsed=None, fail=False):
 class PDFSourceTests(unittest.TestCase):
     """Tests for PDFSource"""
 
-    # ------------------------------------------------------------------ #
-    # Fixtures                                                             #
-    # ------------------------------------------------------------------ #
-
     def setUp(self):
         self._tmpdir = tempfile.TemporaryDirectory()
         self.folder  = Path(self._tmpdir.name)
@@ -114,10 +106,6 @@ class PDFSourceTests(unittest.TestCase):
 
     def ts(self) -> datetime:
         return datetime(2024, 1, 1, tzinfo=timezone.utc)
-
-    # ------------------------------------------------------------------ #
-    # connect / lifecycle                                                  #
-    # ------------------------------------------------------------------ #
 
     def test_connect_succeeds_with_valid_folder(self):
         """connect() must not raise for an existing directory."""
@@ -147,10 +135,6 @@ class PDFSourceTests(unittest.TestCase):
             src.get_content([])
         with self.assertRaises(RuntimeError):
             src.get_all_documents_metadata()
-
-    # ------------------------------------------------------------------ #
-    # get_list_artefacts                                                   #
-    # ------------------------------------------------------------------ #
 
     def test_list_returns_all_when_last_synced_is_none(self):
         """None last_synced must return every PDF discovered."""
@@ -190,10 +174,6 @@ class PDFSourceTests(unittest.TestCase):
         src = self.connect()
         _, ts = src.get_list_artefacts(None)[0]
         self.assertIsNotNone(ts.tzinfo)
-
-    # ------------------------------------------------------------------ #
-    # get_content — pipeline wiring                                        #
-    # ------------------------------------------------------------------ #
 
     def test_get_content_returns_one_per_artefact(self):
         """One Content object must be returned per input artefact."""
@@ -330,9 +310,6 @@ class PDFSourceTests(unittest.TestCase):
         chunks = src.get_content([(pdf.name, self.ts())])[0].content["chunks"]
         self.assertTrue(all(c["vector"] == [] for c in chunks))
 
-    # ------------------------------------------------------------------ #
-    # Metadata — strategy dispatch                                         #
-    # ------------------------------------------------------------------ #
 
     def _src_with_llm(self, llm_payload: dict, **extra_config) -> tuple[PDFSource, Path]:
         """
@@ -561,9 +538,6 @@ class PDFSourceTests(unittest.TestCase):
     def test_parse_author_line_no_match(self):
         self.assertEqual(PDFSource._parse_author_line("not an author line"), [])
 
-    # ------------------------------------------------------------------ #
-    # DocumentMetadata                                                     #
-    # ------------------------------------------------------------------ #
 
     def test_document_metadata_default_fields(self):
         """All optional fields must default to None / empty."""


### PR DESCRIPTION
# Move  the generic PDF file metadata extraction class from the SCEPA pipeline to database-builder-libs

This is one of the last features that should be upstreamed from the SCEPA pipeline to database-builder-libs. This feature is a new pdf source which with its configurable options, allows an user to chunk, embed, extract metadata (such as title, authors, institutions, acknowledgements and date of change) from documents. 

Merging this PR helps to reduce the size of the SCEPA pipeline to just 2 files. I've tested the pipeline with unit-tests and in the actual ingestion pipeline. It works out-of-the-box and I am quite happy with how readable/maintainable this class is.

## Notes about typedb_v2 and typedb_v3 branch

Now that we have typedb_v3 support, my plan is to merge this to main, make a snapshot/release of the repository and then merge the typedb_v3 branch to main (overwriting the typedb_v2 store). 


## Autogenerated

This pull request introduces comprehensive documentation and usage examples for the new `PDFSource` module, which enables parsing, metadata extraction, chunking, and embedding of PDF documents from a local folder. The updates include a detailed user guide, configuration instructions, and integration into the main documentation navigation. Additionally, there are minor documentation corrections elsewhere.

**Key changes:**

**PDFSource documentation and usage:**

* Added a new in-depth guide `main_modules/12_pdf_source.md` describing the design, configuration, and usage patterns of the `PDFSource` class, including interaction patterns, extraction strategies, chunking, embedding, and the structure of returned content objects.
* Integrated the new PDF source documentation into the main documentation navigation by adding it to the `mkdocs.yml` navigation tree.

**Getting Started examples:**

* Expanded `docs/getting_started/02_examples.md` with a new section, "Working with PDF Source," providing practical code examples for connecting to a folder, listing changed files, extracting content, enabling LLM extraction, customizing extraction strategies, skipping known fields, adding chunking/embedding, and quick inventory. [[1]](diffhunk://#diff-de71d2c296c703766efa53975ea795665ff20313af8142811a5794752a709605R8) [[2]](diffhunk://#diff-de71d2c296c703766efa53975ea795665ff20313af8142811a5794752a709605R94-R289)
* Clarified and extended chunking strategy documentation and example code in the same file. [[1]](diffhunk://#diff-de71d2c296c703766efa53975ea795665ff20313af8142811a5794752a709605R492) [[2]](diffhunk://#diff-de71d2c296c703766efa53975ea795665ff20313af8142811a5794752a709605L392)
